### PR TITLE
Add method beatmapset_from_map_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - Now using the specific api version 20220705 which renamed a few fields but only one of those made it through to the interface: `Score::created_at` is now called `Score::ended_at`
   - The `Score::score_id` field is now of type `Option<u64>` instead of `u64`
   - `GameModeAttributes::Taiko` now has an additional field `peak_difficulty` and no longer has the field `ar`
+  - Added method `Osu::beatmapset_from_map_id` to retrieve a mapset using a map ID.
 
 # v0.4.0
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following endpoints are currently supported:
 - `beatmapsets/{mapset_id}`: The beatmapset including all of its difficulty beatmaps
 - `beatmapsets/events`: Various events around a beatmapset such as status, genre, or language updates, kudosu transfers, or new issues
 - `beatmapsets/search`: Search for beatmapsets; the same search as on the osu! website
+- `beatmapsets/lookup`: Find a beatmapset using a beatmap ID.
 - `comments`: Most recent comments and their replies up to two levels deep
 - `forums/topics/{topic_id}`: A forum topic and its posts
 - `matches`: List of currently open multiplayer lobbies

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -181,6 +181,21 @@ impl Osu {
         GetBeatmapset::new(self, mapset_id)
     }
 
+    /// Get a [`Beatmapset`](crate::model::beatmap::Beatmapset) from a map ID.
+    ///
+    /// Filled options will be: `artist_unicode`, `converts`, `description`,
+    /// `genre`, `language`, `legacy_thread_url`, `maps`, `ratings`,
+    /// `ranked_date` (if not unranked), `recent_favourites`,
+    /// `submitted_date` (if submitted), and `title_unicode`.
+    ///
+    /// The contained [`Beatmap`](crate::model::beatmap::Beatmap)s
+    /// will contain `Some` in `fail_times`, `max_combo`
+    /// (if available for mode), and `deleted_at` (if deleted).
+    #[inline]
+    pub fn beatmapset_from_map_id(&self, map_id: u32) -> GetBeatmapsetFromMapId<'_> {
+        GetBeatmapsetFromMapId::new(self, map_id)
+    }
+
     /// Get a [`BeatmapsetEvents`](crate::model::beatmap::BeatmapsetEvents)
     /// struct containing the most recent mapset events.
     #[inline]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -11,6 +11,7 @@ pub(crate) struct Metrics {
     pub(crate) beatmap_difficulty_attributes: IntCounter,
     pub(crate) beatmaps: IntCounter,
     pub(crate) beatmapset: IntCounter,
+    pub(crate) beatmapset_from_map_id: IntCounter,
     pub(crate) beatmapset_events: IntCounter,
     pub(crate) beatmapset_search: IntCounter,
 

--- a/src/request/beatmap.rs
+++ b/src/request/beatmap.rs
@@ -586,6 +586,43 @@ impl<'a> GetBeatmapset<'a> {
 
 poll_req!(GetBeatmapset => Beatmapset);
 
+/// Get a [`Beatmapset`](crate::model::beatmap::Beatmapset) from a beatmap ID.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct GetBeatmapsetFromMapId<'a> {
+    fut: Option<Pending<'a, Beatmapset>>,
+    osu: &'a Osu,
+    map_id: u32,
+}
+
+impl<'a> GetBeatmapsetFromMapId<'a> {
+    #[inline]
+    pub(crate) fn new(osu: &'a Osu, map_id: u32) -> Self {
+        Self {
+            fut: None,
+            osu,
+            map_id,
+        }
+    }
+
+    fn start(&mut self) -> Pending<'a, Beatmapset> {
+        #[cfg(feature = "metrics")]
+        self.osu.metrics.beatmapset_from_map_id.inc();
+
+        let mut query = Query::new();
+
+        query.push("beatmap_id", self.map_id);
+
+        let req = Request::with_query(Route::GetBeatmapsetFromMapId, query);
+
+        let osu = self.osu;
+        let fut = osu.request::<Beatmapset>(req);
+
+        Box::pin(fut)
+    }
+}
+
+poll_req!(GetBeatmapsetFromMapId => Beatmapset);
+
 /// Get a [`BeatmapsetEvents`](crate::model::beatmap::BeatmapsetEvents) struct.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct GetBeatmapsetEvents<'a> {

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -29,6 +29,7 @@ pub(crate) enum Route {
     GetBeatmapset {
         mapset_id: u32,
     },
+    GetBeatmapsetFromMapId,
     GetBeatmapsetEvents,
     GetBeatmapsetSearch,
     GetComments,
@@ -103,6 +104,7 @@ impl Route {
             Self::GetBeatmapset { mapset_id } => {
                 (Method::GET, format!("beatmapsets/{}", mapset_id).into())
             }
+            Self::GetBeatmapsetFromMapId => (Method::GET, "beatmapsets/lookup".into()),
             Self::GetBeatmapsetEvents => (Method::GET, "beatmapsets/events".into()),
             Self::GetBeatmapsetSearch => (Method::GET, "beatmapsets/search".into()),
             Self::GetComments => (Method::GET, "comments".into()),

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -215,6 +215,19 @@ async fn beatmapset() {
 }
 
 #[tokio::test]
+async fn beatmapset_from_map_id() {
+    init().await;
+
+    match osu().beatmapset_from_map_id(ADESSO_BALLA).await {
+        Ok(mapset) => println!("Received mapset with {} maps", mapset.maps.unwrap().len()),
+        Err(why) => {
+            unwind_error!(println, why, "Error while requesting beatmapset: {}");
+            panic!()
+        }
+    }
+}
+
+#[tokio::test]
 async fn beatmapset_events() {
     init().await;
 


### PR DESCRIPTION
This PR adds the ability to search for a beatmapset using a map ID using the beatmapsets/lookup route.