### PR TITLE
Add passed field to score model

### DIFF
--- a/src/model/score_.rs
+++ b/src/model/score_.rs
@@ -43,6 +43,7 @@ pub struct Score {
     #[serde(with = "serde_::datetime")]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
     pub ended_at: OffsetDateTime,
+    pub passed: bool,
     #[serde(rename = "rank")]
     pub grade: Grade,
     pub max_combo: u32,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -516,6 +516,7 @@ fn get_score() -> Score {
     Score {
         accuracy: 98.76,
         ended_at: get_date(),
+        passed: true,
         grade: Grade::A,
         max_combo: 1234,
         map: Some(get_map()),


### PR DESCRIPTION
Useful for failed lazer scores which are submitted with a D rank.