### PR TITLE
perf: put serde::Serialize behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/rosu-v2/"
 
 [features]
 default = ["cache"]
+serialize = []
 cache = ["dashmap"]
 metrics = ["prometheus"]
 replay = ["osu-db"]

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ async fn main() {
 
 ## Features
 
-| Flag      | Description                                                                                                                                                         | deps                                                  |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `default` | Enable the `cache` feature                                                                                                                                          |
-| `cache`   | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids                                                           | [dashmap](https://github.com/xacrimon/dashmap)        |
-| `metrics` | Provide a count of all request types the client makes with the function `Osu::metrics` returning a `prometheus::IntCounterVec`                                      | [prometheus](https://github.com/tikv/rust-prometheus) |
-| `replay`  | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [osu-db](https://github.com/negamartin/osu-db)        |
-| `rkyv`    | Implement rkyv's `Archive`, `Deserialize`, and `Serialize` for most types, allowing for insanely fast (de)serializing.                                              | [rkyv](https://github.com/rkyv/rkyv)                  |
+| Flag        | Description                                                                                                                                                         | deps                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `default`   | Enable the `cache` feature                                                                                                                                          |                                                       |
+| `cache`     | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids                                                           | [dashmap](https://github.com/xacrimon/dashmap)        |
+| `serialize` | Implement `serde::Serialize` for most types, allowing for manual serialization                                                                                      |                                                       |
+| `metrics`   | Provide a count of all request types the client makes with the function `Osu::metrics` returning a `prometheus::IntCounterVec`                                      | [prometheus](https://github.com/tikv/rust-prometheus) |
+| `replay`    | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [osu-db](https://github.com/negamartin/osu-db)        |
+| `rkyv`      | Implement rkyv's `Archive`, `Deserialize`, and `Serialize` for most types, allowing for insanely fast (de)serializing.                                              | [rkyv](https://github.com/rkyv/rkyv)                  |

--- a/src/model/beatmap_.rs
+++ b/src/model/beatmap_.rs
@@ -10,8 +10,7 @@ use serde::{
     de::{
         DeserializeSeed, Deserializer, Error, IgnoredAny, MapAccess, SeqAccess, Unexpected, Visitor,
     },
-    ser::Serializer,
-    Deserialize, Serialize,
+    Deserialize,
 };
 use std::{
     convert::TryFrom,
@@ -23,7 +22,8 @@ use time::OffsetDateTime;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Beatmap {
     pub ar: f32,
@@ -105,7 +105,8 @@ impl PartialEq for Beatmap {
 
 impl Eq for Beatmap {}
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapCompact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -171,7 +172,8 @@ pub(crate) struct BeatmapDifficultyAttributesWrapper {
     pub attributes: BeatmapDifficultyAttributes,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -185,7 +187,8 @@ pub struct BeatmapDifficultyAttributes {
     pub attrs: GameModeAttributes,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -221,7 +224,8 @@ pub enum GameModeAttributes {
 }
 
 /// Represents a beatmapset. This extends [`BeatmapsetCompact`] with additional attributes.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -485,7 +489,8 @@ impl PartialEq for Beatmapset {
 
 impl Eq for Beatmapset {}
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetAvailability {
     pub download_disabled: bool,
@@ -493,7 +498,8 @@ pub struct BeatmapsetAvailability {
     pub more_information: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCommentEdit<T> {
     #[serde(flatten)]
@@ -502,7 +508,8 @@ pub struct BeatmapsetCommentEdit<T> {
     pub new: T,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCommentId {
     #[serde(
@@ -531,7 +538,8 @@ pub struct BeatmapsetCommentId {
     pub mapset_discussion_post_id: Option<u64>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCommentKudosuGain {
     #[serde(flatten)]
@@ -540,13 +548,15 @@ pub struct BeatmapsetCommentKudosuGain {
     pub votes: Vec<BeatmapsetVote>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCommentNominate {
     pub modes: Vec<GameMode>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCommentOwnerChange {
     #[serde(
@@ -572,7 +582,8 @@ pub struct BeatmapsetCommentOwnerChange {
 }
 
 /// Represents a beatmapset.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCompact {
     pub artist: String,
@@ -640,7 +651,8 @@ impl From<Beatmapset> for BeatmapsetCompact {
 }
 
 /// URLs to various sizes of (parts of) the background picture
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetCovers {
     /// Lengthy part of the background
@@ -666,7 +678,8 @@ pub struct BeatmapsetCovers {
     pub slim_cover_2x: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetDiscussion {
     #[serde(rename = "id")]
@@ -723,7 +736,8 @@ impl PartialEq for BeatmapsetDiscussion {
 
 impl Eq for BeatmapsetDiscussion {}
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 #[serde(rename_all = "snake_case", tag = "type")]
 #[non_exhaustive]
@@ -885,7 +899,8 @@ pub enum BeatmapsetEvent {
     },
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetEvents {
     pub events: Vec<BeatmapsetEvent>,
@@ -894,7 +909,8 @@ pub struct BeatmapsetEvents {
     pub users: Vec<UserCompact>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -905,7 +921,8 @@ pub struct BeatmapsetHype {
     pub required: u32,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -916,7 +933,8 @@ pub struct BeatmapsetNominations {
     pub required: u32,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetPost {
     #[serde(rename = "id")]
@@ -949,7 +967,8 @@ pub struct BeatmapsetPost {
     pub deleted_at: Option<OffsetDateTime>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -1029,9 +1048,10 @@ impl<'de> Deserialize<'de> for SearchRankStatus {
     }
 }
 
-impl Serialize for SearchRankStatus {
+#[cfg(feature = "serialize")]
+impl serde::Serialize for SearchRankStatus {
     #[inline]
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: serde::ser::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         match self {
             Self::Any => s.serialize_i8(SEARCH_RANK_STATUS_ANY),
             Self::Specific(status) => s.serialize_i8(*status as i8),
@@ -1039,22 +1059,23 @@ impl Serialize for SearchRankStatus {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub(crate) struct BeatmapsetSearchParameters {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) query: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) mode: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) status: Option<SearchRankStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) genre: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub(crate) language: Option<u8>,
     pub(crate) video: bool,
     pub(crate) storyboard: bool,
     pub(crate) nsfw: bool,
-    #[serde(rename(serialize = "_sort"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "_sort")))]
     sort: BeatmapsetSearchSort,
     descending: bool,
 }
@@ -1161,15 +1182,16 @@ impl<'de> Deserialize<'de> for BeatmapsetSearchParameters {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapsetSearchResult {
     cursor: Option<Cursor>,
     /// All mapsets of the current page
-    #[serde(rename(serialize = "beatmapsets"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "beatmapsets")))]
     pub mapsets: Vec<Beatmapset>,
-    #[serde(rename(serialize = "search"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "search")))]
     pub(crate) params: BeatmapsetSearchParameters,
     /// Total amount of mapsets that fit the search query
     pub total: u32,
@@ -1275,7 +1297,8 @@ macro_rules! search_sort_enum {
     ( $( $( #[$meta:meta] )? $variant:ident => $name:literal ,)+ ) => {
         /// Provides an option to specify a mapset order in a mapset search,
         /// see [`Osu::beatmapset_search`](crate::client::Osu::beatmapset_search).
-        #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+        #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+        #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
         #[cfg_attr(
             feature = "rkyv",
             derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -1354,7 +1377,8 @@ struct SubSort {
     descending: bool,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -1366,7 +1390,8 @@ pub struct BeatmapsetVote {
 }
 
 /// All fields are optional but there's always at least one field returned.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct FailTimes {
     /// List of length 100
@@ -1439,7 +1464,8 @@ impl<'de> Visitor<'de> for HundredU32Visitor {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MostPlayedMap {
     pub count: usize,
@@ -1504,9 +1530,10 @@ impl TryFrom<i8> for RankStatus {
     }
 }
 
-impl Serialize for RankStatus {
+#[cfg(feature = "serialize")]
+impl serde::Serialize for RankStatus {
     #[inline]
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: serde::ser::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_i8(*self as i8)
     }
 }
@@ -1682,12 +1709,13 @@ fn flatten_description<'de, D: Deserializer<'de>>(d: D) -> Result<Option<String>
 }
 
 #[cfg(test)]
-mod tests {
+#[cfg(feature = "serialize")]
+mod serde_tests {
     use super::*;
     use serde::de::DeserializeOwned;
     use std::fmt::Debug;
 
-    fn ser_de<T: DeserializeOwned + Serialize + PartialEq + Debug>(val: T) {
+    fn ser_de<T: DeserializeOwned + serde::Serialize + PartialEq + Debug>(val: T) {
         let serialized =
             serde_json::to_string(&val).unwrap_or_else(|e| panic!("Failed to serialize: {}", e));
 

--- a/src/model/comments_.rs
+++ b/src/model/comments_.rs
@@ -1,7 +1,7 @@
 use super::{serde_, user_::UserCompact, Cursor};
 use crate::{prelude::Username, request::GetUser, Osu, OsuResult};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fmt;
 use time::OffsetDateTime;
 
@@ -9,7 +9,8 @@ use time::OffsetDateTime;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// Represents an single comment.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Comment {
     /// the ID of the comment
@@ -89,7 +90,8 @@ impl PartialEq for Comment {
 impl Eq for Comment {}
 
 /// Comments and related data.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct CommentBundle {
@@ -143,7 +145,8 @@ impl CommentBundle {
 }
 
 /// Available orders for comments
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -175,7 +178,8 @@ impl fmt::Display for CommentSort {
 }
 
 /// Metadata of the object that a comment is attached to.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 #[serde(untagged)]
 pub enum CommentableMeta {

--- a/src/model/cursor.rs
+++ b/src/model/cursor.rs
@@ -1,6 +1,6 @@
 use crate::request::Query;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 
 /// A structure included in some API responses containing the parameters to get the next set of results.
@@ -10,7 +10,8 @@ use serde_json::Value;
 /// If there are no more results available, a cursor with a value of `None` is returned.
 ///
 /// Note that sort option should also be specified for it to work.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 #[serde(transparent)]

--- a/src/model/forum_.rs
+++ b/src/model/forum_.rs
@@ -2,7 +2,7 @@ use super::{serde_, Cursor};
 
 use serde::{
     de::{Deserializer, Error, IgnoredAny, MapAccess, Visitor},
-    Deserialize, Serialize,
+    Deserialize,
 };
 use std::fmt;
 use time::OffsetDateTime;
@@ -10,7 +10,8 @@ use time::OffsetDateTime;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct ForumPosts {
@@ -34,30 +35,37 @@ impl ForumPosts {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct ForumPost {
-    #[serde(with = "serde_::datetime")]
+    #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
     pub created_at: OffsetDateTime,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "serde_::option_datetime"
+    #[cfg_attr(
+        feature = "serialize",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "serde_::option_datetime"
+        )
     )]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeMap))]
     pub deleted_at: Option<OffsetDateTime>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "serde_::option_datetime"
+    #[cfg_attr(
+        feature = "serialize",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "serde_::option_datetime"
+        )
     )]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeMap))]
     pub edited_at: Option<OffsetDateTime>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub edited_by_id: Option<u32>,
     pub forum_id: u32,
     /// Post content in HTML format
     pub html: String,
-    #[serde(rename = "id")]
+    #[cfg_attr(feature = "serialize", serde(rename = "id"))]
     pub post_id: u64,
     /// Post content in BBCode format
     pub raw: String,
@@ -165,14 +173,16 @@ impl PartialEq for ForumPost {
 
 impl Eq for ForumPost {}
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct ForumPostsSearch {
     pub limit: u32,
     pub sort: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct ForumTopic {
     #[serde(with = "serde_::datetime")]

--- a/src/model/grade.rs
+++ b/src/model/grade.rs
@@ -2,7 +2,7 @@ use crate::error::{OsuError, ParsingError};
 
 use serde::{
     de::{Error, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize,
+    Deserialize, Deserializer,
 };
 use std::{fmt, str::FromStr};
 
@@ -11,7 +11,8 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// Enum for a [`Score`](crate::model::score::Score)'s grade (sometimes called rank)
 #[allow(clippy::upper_case_acronyms, missing_docs)]
-#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, PartialOrd, Serialize)]
+#[derive(Copy, Clone, Hash, Debug, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),

--- a/src/model/kudosu_.rs
+++ b/src/model/kudosu_.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use time::OffsetDateTime;
 
 use crate::model::user_::Username;
@@ -6,7 +6,8 @@ use crate::model::user_::Username;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -23,7 +24,8 @@ pub enum KudosuAction {
     VoteReset,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct KudosuGiver {
     pub url: String,
@@ -31,7 +33,8 @@ pub struct KudosuGiver {
     pub username: Username,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct KudosuHistory {
     pub id: u32,
@@ -60,7 +63,8 @@ impl PartialEq for KudosuHistory {
 
 impl Eq for KudosuHistory {}
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct KudosuPost {
     /// Url of the object.

--- a/src/model/matches_.rs
+++ b/src/model/matches_.rs
@@ -9,85 +9,85 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 use serde::{
     de::{Deserializer, Error, IgnoredAny, MapAccess, SeqAccess, Unexpected, Visitor},
-    ser::{SerializeSeq, Serializer},
-    Deserialize, Serialize,
+    Deserialize,
 };
 use std::{collections::HashMap, fmt, slice::Iter, vec::Drain};
 use time::OffsetDateTime;
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
-#[serde(tag = "type")]
+#[cfg_attr(feature = "serialize", serde(tag = "type"))]
 pub enum MatchEvent {
     /// The match was created
-    #[serde(rename(serialize = "match-created"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "match-created")))]
     Create {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
         user_id: Option<u32>,
     },
     /// The match was closed
-    #[serde(rename(serialize = "match-disbanded"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "match-disbanded")))]
     Disbanded {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
     },
     /// A map is / was being played
-    #[serde(rename(serialize = "other"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "other")))]
     Game {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
         /// Boxed to optimize [`MatchEvent`](crate::model::matches::MatchEvent)'s
         /// size in memory.
         game: Box<MatchGame>,
-        #[serde(default)]
+        #[cfg_attr(feature = "serialize", serde(default))]
         match_name: String,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
     },
     /// The match host changed
-    #[serde(rename(serialize = "host-changed"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "host-changed")))]
     HostChanged {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
         user_id: u32,
     },
     /// A player joined the match
-    #[serde(rename(serialize = "player-joined"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "player-joined")))]
     Joined {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
         user_id: u32,
     },
     /// A player was kicked from the match
-    #[serde(rename(serialize = "player-kicked"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "player-kicked")))]
     Kicked {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
         user_id: u32,
     },
     /// A player left the match
-    #[serde(rename(serialize = "player-left"))]
+    #[cfg_attr(feature = "serialize", serde(rename(serialize = "player-left")))]
     Left {
-        #[serde(rename(serialize = "id"))]
+        #[cfg_attr(feature = "serialize", serde(rename(serialize = "id")))]
         event_id: u64,
-        #[serde(with = "serde_::datetime")]
+        #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         timestamp: OffsetDateTime,
         user_id: u32,
@@ -299,7 +299,8 @@ impl<'de> Deserialize<'de> for MatchEvent {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MatchGame {
     #[serde(rename = "id")]
@@ -424,7 +425,8 @@ impl<'m> DoubleEndedIterator for MatchGameDrain<'m> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MatchInfo {
     #[serde(
@@ -451,7 +453,8 @@ impl PartialEq for MatchInfo {
 
 impl Eq for MatchInfo {}
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MatchList {
@@ -477,18 +480,20 @@ impl MatchList {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MatchListParams {
     pub limit: u32,
     pub sort: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MatchScore {
     /// Accuracy between `0.0` and `100.0`
-    #[serde(with = "serde_::adjust_acc")]
+    #[cfg_attr(feature = "serialize", serde(with = "serde_::adjust_acc"))]
     pub accuracy: f32,
     pub max_combo: u32,
     pub mods: GameMods,
@@ -620,14 +625,18 @@ impl<'de> Deserialize<'de> for MatchUsers {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct OsuMatch {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub current_game_id: Option<u64>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        with = "serde_::option_datetime"
+    #[cfg_attr(
+        feature = "serialize",
+        serde(
+            skip_serializing_if = "Option::is_none",
+            with = "serde_::option_datetime"
+        )
     )]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeMap))]
     pub end_time: Option<OffsetDateTime>,
@@ -636,18 +645,21 @@ pub struct OsuMatch {
     pub latest_event_id: u64,
     pub match_id: u32,
     pub name: String,
-    #[serde(with = "serde_::datetime")]
+    #[cfg_attr(feature = "serialize", serde(with = "serde_::datetime"))]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
     pub start_time: OffsetDateTime,
     /// Maps user ids to users
-    #[serde(serialize_with = "serialize_match_users")]
+    #[cfg_attr(feature = "serialize", serde(serialize_with = "serialize_match_users"))]
     pub users: HashMap<u32, UserCompact>,
 }
 
-fn serialize_match_users<S: Serializer>(
+#[cfg(feature = "serialize")]
+fn serialize_match_users<S: serde::ser::Serializer>(
     users: &HashMap<u32, UserCompact>,
     s: S,
 ) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeSeq;
+
     let mut seq = s.serialize_seq(Some(users.len()))?;
 
     for user in users.values() {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -59,6 +59,7 @@ macro_rules! def_enum {
             }
         }
 
+        #[cfg(feature = "serialize")]
         impl serde::Serialize for $type {
             #[inline]
             fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {

--- a/src/model/mode.rs
+++ b/src/model/mode.rs
@@ -1,6 +1,6 @@
 use serde::{
     de::{Error, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer,
 };
 use std::fmt;
 
@@ -107,9 +107,10 @@ impl<'de> Deserialize<'de> for GameMode {
     }
 }
 
-impl Serialize for GameMode {
+#[cfg(feature = "serialize")]
+impl serde::Serialize for GameMode {
     #[inline]
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: serde::ser::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_u8(*self as u8)
     }
 }

--- a/src/model/mods.rs
+++ b/src/model/mods.rs
@@ -8,7 +8,7 @@ use crate::{
 use bitflags::bitflags;
 use serde::{
     de::{Error, IgnoredAny, MapAccess, SeqAccess, Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize, Deserializer,
 };
 use std::{
     convert::{Into, TryFrom},
@@ -526,9 +526,10 @@ impl<'de> Deserialize<'de> for GameMods {
     }
 }
 
-impl Serialize for GameMods {
+#[cfg(feature = "serialize")]
+impl serde::Serialize for GameMods {
     #[inline]
-    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: serde::ser::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_u32(self.bits)
     }
 }

--- a/src/model/news_.rs
+++ b/src/model/news_.rs
@@ -1,13 +1,14 @@
 use super::{serde_, Cursor};
 use crate::{prelude::Username, Osu, OsuResult};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use time::OffsetDateTime;
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct News {
@@ -36,7 +37,8 @@ impl News {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct NewsPost {
     #[serde(rename = "id")]
@@ -74,7 +76,8 @@ impl PartialEq for NewsPost {
 
 impl Eq for NewsPost {}
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 // TODO
 // #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct NewsSearch {
@@ -83,7 +86,8 @@ pub struct NewsSearch {
     pub limit: u32,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct NewsSidebar {
     pub current_year: u32,

--- a/src/model/recent_event_.rs
+++ b/src/model/recent_event_.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use time::OffsetDateTime;
 
 use super::{
@@ -12,7 +12,8 @@ use super::{
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// The object has different attributes depending on its type.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct RecentEvent {
     #[serde(with = "serde_::datetime")]
@@ -24,21 +25,24 @@ pub struct RecentEvent {
     pub event_type: EventType,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct EventBeatmap {
     pub title: String,
     pub url: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct EventBeatmapset {
     pub title: String,
     pub url: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum EventType {
@@ -112,7 +116,8 @@ pub enum EventType {
     },
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct EventUser {
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::UsernameWrapper))]

--- a/src/model/score_.rs
+++ b/src/model/score_.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{request::GetUser, Osu};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
@@ -17,7 +17,8 @@ pub(crate) struct BeatmapScores {
     pub(crate) scores: Vec<Score>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct BeatmapUserScore {
     /// The position of the score within the requested beatmap ranking
@@ -35,7 +36,8 @@ impl BeatmapUserScore {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Score {
     #[serde(with = "serde_::adjust_acc")]
@@ -138,7 +140,8 @@ pub(crate) struct Scores {
     pub(crate) scores: Vec<Score>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -206,7 +209,8 @@ impl ScoreStatistics {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),

--- a/src/model/seasonal_backgrounds_.rs
+++ b/src/model/seasonal_backgrounds_.rs
@@ -1,14 +1,15 @@
 use super::serde_;
 use crate::model::user_::UserCompact;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use time::OffsetDateTime;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// Details of a background
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct SeasonalBackground {
     /// URL to the image
@@ -19,7 +20,8 @@ pub struct SeasonalBackground {
 }
 
 /// Collection of seasonal backgrounds
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct SeasonalBackgrounds {
     /// End date of the backgrounds

--- a/src/model/user_.rs
+++ b/src/model/user_.rs
@@ -2,7 +2,7 @@ use super::{serde_, GameMode};
 
 use serde::{
     de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
-    Deserialize, Deserializer, Serialize,
+    Deserialize, Deserializer,
 };
 use smallstr::SmallString;
 use std::fmt;
@@ -11,7 +11,8 @@ use time::{Date, OffsetDateTime};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct AccountHistory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -27,7 +28,8 @@ pub struct AccountHistory {
     pub permanent: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Badge {
     #[serde(with = "serde_::datetime")]
@@ -115,7 +117,8 @@ where
 }
 
 /// Counts of grades of a [`User`].
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -145,7 +148,8 @@ fn deserialize_i32_default<'de, D: Deserializer<'de>>(d: D) -> Result<i32, D::Er
 }
 
 /// Describes a Group membership of a [`User`].
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Group {
     #[serde(rename = "colour")]
@@ -167,7 +171,8 @@ pub struct Group {
     pub short_name: String,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(
     feature = "rkyv",
@@ -181,7 +186,8 @@ pub enum HistoryType {
     Silence,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct Medal {
     pub description: String,
@@ -206,7 +212,8 @@ impl PartialEq for Medal {
 
 impl Eq for Medal {}
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MedalCompact {
     #[serde(with = "serde_::datetime")]
@@ -216,7 +223,8 @@ pub struct MedalCompact {
     pub medal_id: u32,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct MonthlyCount {
     #[serde(with = "serde_::date")]
@@ -225,7 +233,8 @@ pub struct MonthlyCount {
     pub count: i32,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct ProfileBanner {
     pub id: u32,
@@ -242,7 +251,8 @@ impl PartialEq for ProfileBanner {
 
 impl Eq for ProfileBanner {}
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -259,7 +269,8 @@ pub enum Playstyle {
     Touch,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -277,7 +288,8 @@ pub enum ProfilePage {
 }
 
 /// Represents a User. Extends [`UserCompact`] object with additional attributes.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct User {
     /// url of user's avatar
@@ -483,7 +495,8 @@ pub struct User {
 }
 
 /// Mainly used for embedding in certain responses to save additional api lookups.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct UserCompact {
     /// url of user's avatar
@@ -693,7 +706,8 @@ impl From<User> for UserCompact {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct UserCover {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -703,7 +717,8 @@ pub struct UserCover {
     pub id: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct UserHighestRank {
     pub rank: u32,
@@ -713,7 +728,8 @@ pub struct UserHighestRank {
 }
 
 /// Kudosu of a [`User`]
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -727,7 +743,8 @@ pub struct UserKudosu {
 }
 
 /// Level progression of a [`User`].
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, RkyvDeserialize, RkyvSerialize),
@@ -760,7 +777,8 @@ impl UserLevel {
 /// osu! usernames are at most 15 ASCII characters long
 pub type Username = SmallString<[u8; 15]>;
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct UserPage {
     pub html: String,
@@ -768,7 +786,8 @@ pub struct UserPage {
 }
 
 /// A summary of various gameplay statistics for a [`User`]. Specific to a [`GameMode`]
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct UserStatistics {
     /// Hit accuracy percentage

--- a/src/model/wiki_.rs
+++ b/src/model/wiki_.rs
@@ -1,10 +1,11 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
 /// Represents a wiki article
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
 pub struct WikiPage {
     /// All available locales for the article

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,910 +1,918 @@
 extern crate rosu_v2;
 
-use rosu_v2::prelude::*;
-use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::HashMap, fmt::Debug};
-use time::{Date, Duration, OffsetDateTime};
+mod types {
+    #![allow(unused)]
 
-fn ser_de<T>(val: &T)
-where
-    T: DeserializeOwned + Serialize + PartialEq + Debug,
-{
-    let serialized =
-        serde_json::to_string(val).unwrap_or_else(|e| panic!("Failed to serialize: {}", e));
+    use rosu_v2::prelude::*;
+    use std::collections::HashMap;
+    use time::{Date, Duration, OffsetDateTime};
 
-    let deserialized: T = serde_json::from_str(&serialized)
-        .unwrap_or_else(|e| panic!("Failed to deserialize: {}\n{serialized}", e));
-
-    assert_eq!(val, &deserialized);
-}
-
-fn get_chart_rankings() -> ChartRankings {
-    ChartRankings {
-        mapsets: vec![get_mapset()],
-        ranking: vec![get_user_compact()],
-        spotlight: get_spotlight(),
+    pub(super) fn get_chart_rankings() -> ChartRankings {
+        ChartRankings {
+            mapsets: vec![get_mapset()],
+            ranking: vec![get_user_compact()],
+            spotlight: get_spotlight(),
+        }
     }
-}
 
-fn get_country_ranking() -> CountryRanking {
-    CountryRanking {
-        active_users: 2,
-        country: "belgiania".to_owned(),
-        country_code: "be".into(),
-        playcount: 420,
-        pp: 123.45,
-        ranked_score: 1_000_000_000_000_000,
+    pub(super) fn get_country_ranking() -> CountryRanking {
+        CountryRanking {
+            active_users: 2,
+            country: "belgiania".to_owned(),
+            country_code: "be".into(),
+            playcount: 420,
+            pp: 123.45,
+            ranked_score: 1_000_000_000_000_000,
+        }
     }
-}
 
-fn get_cursor() -> Cursor {
-    let json = r#"{"cursor":{"a":123,"b":"henlo","c":true,"d":[1, 2, 3]}}"#;
+    pub(super) fn get_cursor() -> Cursor {
+        let json = r#"{"cursor":{"a":123,"b":"henlo","c":true,"d":[1, 2, 3]}}"#;
 
-    serde_json::from_str(json).unwrap()
-}
-
-fn get_date() -> OffsetDateTime {
-    let mut now = OffsetDateTime::now_utc();
-    now -= Duration::nanoseconds(now.nanosecond() as i64);
-
-    now
-}
-
-fn get_forum_posts() -> ForumPosts {
-    ForumPosts {
-        cursor: Some(get_cursor()),
-        posts: vec![ForumPost {
-            created_at: get_date(),
-            deleted_at: Some(get_date()),
-            edited_at: Some(get_date()),
-            edited_by_id: Some(123),
-            forum_id: 1234,
-            html: "big boi html".to_owned(),
-            post_id: 12345,
-            raw: "raaaaaaw html".to_owned(),
-            topic_id: 1234567,
-            user_id: 12345678,
-        }],
-        search: ForumPostsSearch {
-            limit: 42,
-            sort: "id_desc".to_owned(),
-        },
-        topic: ForumTopic {
-            created_at: get_date(),
-            deleted_at: Some(get_date()),
-            first_post_id: 10,
-            forum_id: 20,
-            is_locked: false,
-            kind: "some type".to_owned(),
-            last_post_id: 30,
-            post_count: 40,
-            title: "epic topic".to_owned(),
-            topic_id: 50,
-            updated_at: Some(get_date()),
-            user_id: 60,
-        },
+        serde_json::from_str(json).unwrap()
     }
-}
 
-fn get_mapset_covers() -> BeatmapsetCovers {
-    BeatmapsetCovers {
-        cover: String::new(),
-        cover_2x: String::new(),
-        card: String::new(),
-        card_2x: String::new(),
-        list: String::new(),
-        list_2x: String::new(),
-        slim_cover: String::new(),
-        slim_cover_2x: String::new(),
+    pub(super) fn get_date() -> OffsetDateTime {
+        let mut now = OffsetDateTime::now_utc();
+        now -= Duration::nanoseconds(now.nanosecond() as i64);
+
+        now
     }
-}
 
-fn get_mapset() -> Beatmapset {
-    Beatmapset {
-        artist: "artist".to_owned(),
-        artist_unicode: Some("äöü".to_owned()),
-        availability: BeatmapsetAvailability {
-            download_disabled: true,
-            more_information: Some("hi".to_owned()),
-        },
-        bpm: 183.2,
-        can_be_hyped: true,
-        converts: Some(vec![]),
-        covers: get_mapset_covers(),
-        creator: Some(get_user_compact()),
-        creator_name: "god".into(),
-        creator_id: 2,
-        description: Some("description".to_owned()),
-        discussion_enabled: true,
-        discussion_locked: false,
-        favourite_count: 1_111_111,
-        genre: Some(Genre::Electronic),
-        hype: Some(BeatmapsetHype {
-            current: 1,
-            required: 2,
-        }),
-        is_scoreable: true,
-        language: Some(Language::Spanish),
-        last_updated: get_date(),
-        legacy_thread_url: Some(String::new()),
-        maps: Some(vec![]),
-        mapset_id: 12345,
-        nominations_summary: BeatmapsetNominations {
-            current: 1,
-            required: 2,
-        },
-        nsfw: true,
-        playcount: 0,
-        preview_url: "b.ppy.sh/preview/12345.mp3".to_owned(),
-        ratings: Some(vec![1, 2, 3, 4, 5, 6]),
-        ranked_date: Some(get_date()),
-        recent_favourites: Some(vec![get_user_compact()]),
-        source: String::new(),
-        status: RankStatus::WIP,
-        storyboard: true,
-        submitted_date: Some(get_date()),
-        tags: "tags".to_owned(),
-        title: "title".to_owned(),
-        title_unicode: Some(String::new()),
-        video: false,
-    }
-}
-
-fn get_map() -> Beatmap {
-    Beatmap {
-        ar: 9.3,
-        bpm: 182.3,
-        checksum: Some(String::new()),
-        convert: false,
-        count_circles: 1234,
-        count_sliders: 123,
-        count_spinners: 1,
-        creator_id: 456,
-        cs: 4.1,
-        deleted_at: Some(get_date()),
-        fail_times: Some(FailTimes {
-            exit: Some(vec![1, 2, 3]),
-            fail: Some(vec![4, 5, 6]),
-        }),
-        hp: 7.5,
-        is_scoreable: true,
-        last_updated: get_date(),
-        map_id: 123456,
-        mapset: Some(get_mapset()),
-        mapset_id: 12345,
-        max_combo: Some(1750),
-        mode: GameMode::Osu,
-        od: 7.5,
-        passcount: 1_000,
-        playcount: 10_000,
-        seconds_drain: 234,
-        seconds_total: 256,
-        stars: 5.89,
-        status: RankStatus::Approved,
-        url: "https://osu.ppy.sh/beatmaps/123456".to_owned(),
-        version: "Insane".to_owned(),
-    }
-}
-
-fn get_map_compact() -> BeatmapCompact {
-    BeatmapCompact {
-        checksum: Some("ABC123".to_owned()),
-        creator_id: 456,
-        fail_times: None,
-        map_id: 123456,
-        mapset: Some(get_mapset_compact()),
-        max_combo: Some(1000),
-        mode: GameMode::Catch,
-        seconds_total: 120,
-        stars: 5.5,
-        status: RankStatus::Loved,
-        version: "HIAAAA".to_owned(),
-    }
-}
-
-fn get_mapset_compact() -> BeatmapsetCompact {
-    BeatmapsetCompact {
-        artist: "artist".to_owned(),
-        artist_unicode: Some("äöü".to_owned()),
-        covers: get_mapset_covers(),
-        creator_name: "god".into(),
-        creator_id: 2,
-        favourite_count: 1_234_567,
-        genre: Some(Genre::Rock),
-        hype: Some(BeatmapsetHype {
-            current: 1,
-            required: 2,
-        }),
-        language: Some(Language::German),
-        mapset_id: 12345,
-        nsfw: false,
-        playcount: 56_789,
-        preview_url: "b.ppy.sh/preview/12345.mp3".to_owned(),
-        source: String::new(),
-        status: RankStatus::Graveyard,
-        title: "title".to_owned(),
-        title_unicode: Some(String::new()),
-        video: true,
-    }
-}
-
-fn get_mapset_discussion() -> BeatmapsetDiscussion {
-    BeatmapsetDiscussion {
-        discussion_id: 0,
-        mapset_id: 1,
-        map_id: Some(2),
-        user_id: 3,
-        deleted_by_id: Some(4),
-        message_type: "suggestion".to_owned(),
-        parent_id: Some(5),
-        timestamp: Some(6),
-        resolved: false,
-        can_be_resolved: true,
-        can_grant_kudosu: false,
-        created_at: get_date(),
-        updated_at: Some(get_date()),
-        deleted_at: Some(get_date()),
-        last_post_at: get_date(),
-        kudosu_denied: true,
-        starting_post: BeatmapsetPost {
-            post_id: 7,
-            discussion_id: 0,
-            user_id: 8,
-            last_editor_id: Some(9),
-            deleted_by_id: Some(10),
-            system: false,
-            message: "cool story bro".to_owned(),
-            created_at: get_date(),
-            updated_at: Some(get_date()),
-            deleted_at: Some(get_date()),
-        },
-    }
-}
-
-fn get_mapset_events() -> BeatmapsetEvents {
-    BeatmapsetEvents {
-        events: vec![
-            BeatmapsetEvent::Disqualify {
-                event_id: 10,
-                comment: BeatmapsetCommentId {
-                    map_discussion_id: None,
-                    map_discussion_post_id: None,
-                    mapset_discussion_id: None,
-                    mapset_discussion_post_id: None,
-                },
+    pub(super) fn get_forum_posts() -> ForumPosts {
+        ForumPosts {
+            cursor: Some(get_cursor()),
+            posts: vec![ForumPost {
                 created_at: get_date(),
-                mapset: get_mapset_compact(),
-                user_id: 123456,
-                discussion: get_mapset_discussion(),
+                deleted_at: Some(get_date()),
+                edited_at: Some(get_date()),
+                edited_by_id: Some(123),
+                forum_id: 1234,
+                html: "big boi html".to_owned(),
+                post_id: 12345,
+                raw: "raaaaaaw html".to_owned(),
+                topic_id: 1234567,
+                user_id: 12345678,
+            }],
+            search: ForumPostsSearch {
+                limit: 42,
+                sort: "id_desc".to_owned(),
             },
-            BeatmapsetEvent::GenreEdit {
-                event_id: 0,
-                comment: BeatmapsetCommentEdit {
-                    comment_id: BeatmapsetCommentId {
+            topic: ForumTopic {
+                created_at: get_date(),
+                deleted_at: Some(get_date()),
+                first_post_id: 10,
+                forum_id: 20,
+                is_locked: false,
+                kind: "some type".to_owned(),
+                last_post_id: 30,
+                post_count: 40,
+                title: "epic topic".to_owned(),
+                topic_id: 50,
+                updated_at: Some(get_date()),
+                user_id: 60,
+            },
+        }
+    }
+
+    pub(super) fn get_mapset_covers() -> BeatmapsetCovers {
+        BeatmapsetCovers {
+            cover: String::new(),
+            cover_2x: String::new(),
+            card: String::new(),
+            card_2x: String::new(),
+            list: String::new(),
+            list_2x: String::new(),
+            slim_cover: String::new(),
+            slim_cover_2x: String::new(),
+        }
+    }
+
+    pub(super) fn get_mapset() -> Beatmapset {
+        Beatmapset {
+            artist: "artist".to_owned(),
+            artist_unicode: Some("äöü".to_owned()),
+            availability: BeatmapsetAvailability {
+                download_disabled: true,
+                more_information: Some("hi".to_owned()),
+            },
+            bpm: 183.2,
+            can_be_hyped: true,
+            converts: Some(vec![]),
+            covers: get_mapset_covers(),
+            creator: Some(get_user_compact()),
+            creator_name: "god".into(),
+            creator_id: 2,
+            description: Some("description".to_owned()),
+            discussion_enabled: true,
+            discussion_locked: false,
+            favourite_count: 1_111_111,
+            genre: Some(Genre::Electronic),
+            hype: Some(BeatmapsetHype {
+                current: 1,
+                required: 2,
+            }),
+            is_scoreable: true,
+            language: Some(Language::Spanish),
+            last_updated: get_date(),
+            legacy_thread_url: Some(String::new()),
+            maps: Some(vec![]),
+            mapset_id: 12345,
+            nominations_summary: BeatmapsetNominations {
+                current: 1,
+                required: 2,
+            },
+            nsfw: true,
+            playcount: 0,
+            preview_url: "b.ppy.sh/preview/12345.mp3".to_owned(),
+            ratings: Some(vec![1, 2, 3, 4, 5, 6]),
+            ranked_date: Some(get_date()),
+            recent_favourites: Some(vec![get_user_compact()]),
+            source: String::new(),
+            status: RankStatus::WIP,
+            storyboard: true,
+            submitted_date: Some(get_date()),
+            tags: "tags".to_owned(),
+            title: "title".to_owned(),
+            title_unicode: Some(String::new()),
+            video: false,
+        }
+    }
+
+    pub(super) fn get_map() -> Beatmap {
+        Beatmap {
+            ar: 9.3,
+            bpm: 182.3,
+            checksum: Some(String::new()),
+            convert: false,
+            count_circles: 1234,
+            count_sliders: 123,
+            count_spinners: 1,
+            creator_id: 456,
+            cs: 4.1,
+            deleted_at: Some(get_date()),
+            fail_times: Some(FailTimes {
+                exit: Some(vec![1, 2, 3]),
+                fail: Some(vec![4, 5, 6]),
+            }),
+            hp: 7.5,
+            is_scoreable: true,
+            last_updated: get_date(),
+            map_id: 123456,
+            mapset: Some(get_mapset()),
+            mapset_id: 12345,
+            max_combo: Some(1750),
+            mode: GameMode::Osu,
+            od: 7.5,
+            passcount: 1_000,
+            playcount: 10_000,
+            seconds_drain: 234,
+            seconds_total: 256,
+            stars: 5.89,
+            status: RankStatus::Approved,
+            url: "https://osu.ppy.sh/beatmaps/123456".to_owned(),
+            version: "Insane".to_owned(),
+        }
+    }
+
+    pub(super) fn get_map_compact() -> BeatmapCompact {
+        BeatmapCompact {
+            checksum: Some("ABC123".to_owned()),
+            creator_id: 456,
+            fail_times: None,
+            map_id: 123456,
+            mapset: Some(get_mapset_compact()),
+            max_combo: Some(1000),
+            mode: GameMode::Catch,
+            seconds_total: 120,
+            stars: 5.5,
+            status: RankStatus::Loved,
+            version: "HIAAAA".to_owned(),
+        }
+    }
+
+    pub(super) fn get_mapset_compact() -> BeatmapsetCompact {
+        BeatmapsetCompact {
+            artist: "artist".to_owned(),
+            artist_unicode: Some("äöü".to_owned()),
+            covers: get_mapset_covers(),
+            creator_name: "god".into(),
+            creator_id: 2,
+            favourite_count: 1_234_567,
+            genre: Some(Genre::Rock),
+            hype: Some(BeatmapsetHype {
+                current: 1,
+                required: 2,
+            }),
+            language: Some(Language::German),
+            mapset_id: 12345,
+            nsfw: false,
+            playcount: 56_789,
+            preview_url: "b.ppy.sh/preview/12345.mp3".to_owned(),
+            source: String::new(),
+            status: RankStatus::Graveyard,
+            title: "title".to_owned(),
+            title_unicode: Some(String::new()),
+            video: true,
+        }
+    }
+
+    pub(super) fn get_mapset_discussion() -> BeatmapsetDiscussion {
+        BeatmapsetDiscussion {
+            discussion_id: 0,
+            mapset_id: 1,
+            map_id: Some(2),
+            user_id: 3,
+            deleted_by_id: Some(4),
+            message_type: "suggestion".to_owned(),
+            parent_id: Some(5),
+            timestamp: Some(6),
+            resolved: false,
+            can_be_resolved: true,
+            can_grant_kudosu: false,
+            created_at: get_date(),
+            updated_at: Some(get_date()),
+            deleted_at: Some(get_date()),
+            last_post_at: get_date(),
+            kudosu_denied: true,
+            starting_post: BeatmapsetPost {
+                post_id: 7,
+                discussion_id: 0,
+                user_id: 8,
+                last_editor_id: Some(9),
+                deleted_by_id: Some(10),
+                system: false,
+                message: "cool story bro".to_owned(),
+                created_at: get_date(),
+                updated_at: Some(get_date()),
+                deleted_at: Some(get_date()),
+            },
+        }
+    }
+
+    pub(super) fn get_mapset_events() -> BeatmapsetEvents {
+        BeatmapsetEvents {
+            events: vec![
+                BeatmapsetEvent::Disqualify {
+                    event_id: 10,
+                    comment: BeatmapsetCommentId {
+                        map_discussion_id: None,
+                        map_discussion_post_id: None,
+                        mapset_discussion_id: None,
+                        mapset_discussion_post_id: None,
+                    },
+                    created_at: get_date(),
+                    mapset: get_mapset_compact(),
+                    user_id: 123456,
+                    discussion: get_mapset_discussion(),
+                },
+                BeatmapsetEvent::GenreEdit {
+                    event_id: 0,
+                    comment: BeatmapsetCommentEdit {
+                        comment_id: BeatmapsetCommentId {
+                            map_discussion_id: Some(0),
+                            map_discussion_post_id: Some(1),
+                            mapset_discussion_id: Some(0),
+                            mapset_discussion_post_id: Some(1),
+                        },
+                        old: Genre::HipHop,
+                        new: Genre::Unspecified,
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                },
+                BeatmapsetEvent::IssueReopen {
+                    event_id: 1,
+                    comment: BeatmapsetCommentId {
+                        map_discussion_id: Some(2),
+                        map_discussion_post_id: None,
+                        mapset_discussion_id: Some(2),
+                        mapset_discussion_post_id: None,
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                    discussion: get_mapset_discussion(),
+                },
+                BeatmapsetEvent::IssueResolve {
+                    event_id: 2,
+                    comment: BeatmapsetCommentId {
+                        map_discussion_id: None,
+                        map_discussion_post_id: Some(3),
+                        mapset_discussion_id: None,
+                        mapset_discussion_post_id: Some(3),
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                    discussion: get_mapset_discussion(),
+                },
+                BeatmapsetEvent::KudosuDeny {
+                    event_id: 8,
+                    comment: BeatmapsetCommentId {
+                        map_discussion_id: None,
+                        map_discussion_post_id: Some(3),
+                        mapset_discussion_id: None,
+                        mapset_discussion_post_id: Some(3),
+                    },
+                    created_at: get_date(),
+                    mapset: get_mapset_compact(),
+                    discussion: get_mapset_discussion(),
+                },
+                BeatmapsetEvent::KudosuGain {
+                    event_id: 3,
+                    comment: BeatmapsetCommentKudosuGain {
+                        comment_id: BeatmapsetCommentId {
+                            map_discussion_id: None,
+                            map_discussion_post_id: None,
+                            mapset_discussion_id: None,
+                            mapset_discussion_post_id: None,
+                        },
+                        new_vote: BeatmapsetVote {
+                            user_id: 111_111,
+                            score: 42,
+                        },
+                        votes: vec![BeatmapsetVote {
+                            user_id: 222_222,
+                            score: 420,
+                        }],
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                    discussion: get_mapset_discussion(),
+                },
+                BeatmapsetEvent::LanguageEdit {
+                    event_id: 4,
+                    comment: BeatmapsetCommentEdit {
+                        comment_id: BeatmapsetCommentId {
+                            map_discussion_id: None,
+                            map_discussion_post_id: None,
+                            mapset_discussion_id: None,
+                            mapset_discussion_post_id: None,
+                        },
+                        old: Language::Any,
+                        new: Language::Polish,
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                },
+                BeatmapsetEvent::Nominate {
+                    event_id: 5,
+                    comment: BeatmapsetCommentNominate {
+                        modes: vec![
+                            GameMode::Osu,
+                            GameMode::Taiko,
+                            GameMode::Catch,
+                            GameMode::Mania,
+                        ],
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                },
+                BeatmapsetEvent::NsfwToggle {
+                    event_id: 6,
+                    comment: BeatmapsetCommentEdit {
+                        comment_id: BeatmapsetCommentId {
+                            map_discussion_id: None,
+                            map_discussion_post_id: None,
+                            mapset_discussion_id: None,
+                            mapset_discussion_post_id: None,
+                        },
+                        old: true,
+                        new: false,
+                    },
+                    created_at: get_date(),
+                    user_id: 123456,
+                    mapset: get_mapset_compact(),
+                },
+                BeatmapsetEvent::OwnerChange {
+                    event_id: 9,
+                    comment: BeatmapsetCommentOwnerChange {
                         map_discussion_id: Some(0),
                         map_discussion_post_id: Some(1),
-                        mapset_discussion_id: Some(0),
-                        mapset_discussion_post_id: Some(1),
+                        map_id: 123,
+                        version: "epic version".to_owned(),
+                        new_user_id: 98,
+                        new_username: "new name".into(),
                     },
-                    old: Genre::HipHop,
-                    new: Genre::Unspecified,
+                    created_at: get_date(),
+                    user_id: 99,
+                    mapset: get_mapset_compact(),
                 },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::IssueReopen {
-                event_id: 1,
-                comment: BeatmapsetCommentId {
-                    map_discussion_id: Some(2),
-                    map_discussion_post_id: None,
-                    mapset_discussion_id: Some(2),
-                    mapset_discussion_post_id: None,
+                BeatmapsetEvent::Rank {
+                    event_id: 7,
+                    created_at: get_date(),
+                    mapset: get_mapset_compact(),
                 },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-                discussion: get_mapset_discussion(),
-            },
-            BeatmapsetEvent::IssueResolve {
-                event_id: 2,
-                comment: BeatmapsetCommentId {
-                    map_discussion_id: None,
-                    map_discussion_post_id: Some(3),
-                    mapset_discussion_id: None,
-                    mapset_discussion_post_id: Some(3),
+                BeatmapsetEvent::Qualify {
+                    event_id: 8,
+                    created_at: get_date(),
+                    mapset: get_mapset_compact(),
                 },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-                discussion: get_mapset_discussion(),
-            },
-            BeatmapsetEvent::KudosuDeny {
-                event_id: 8,
-                comment: BeatmapsetCommentId {
-                    map_discussion_id: None,
-                    map_discussion_post_id: Some(3),
-                    mapset_discussion_id: None,
-                    mapset_discussion_post_id: Some(3),
-                },
-                created_at: get_date(),
-                mapset: get_mapset_compact(),
-                discussion: get_mapset_discussion(),
-            },
-            BeatmapsetEvent::KudosuGain {
-                event_id: 3,
-                comment: BeatmapsetCommentKudosuGain {
-                    comment_id: BeatmapsetCommentId {
-                        map_discussion_id: None,
-                        map_discussion_post_id: None,
-                        mapset_discussion_id: None,
-                        mapset_discussion_post_id: None,
-                    },
-                    new_vote: BeatmapsetVote {
-                        user_id: 111_111,
-                        score: 42,
-                    },
-                    votes: vec![BeatmapsetVote {
-                        user_id: 222_222,
-                        score: 420,
-                    }],
-                },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-                discussion: get_mapset_discussion(),
-            },
-            BeatmapsetEvent::LanguageEdit {
-                event_id: 4,
-                comment: BeatmapsetCommentEdit {
-                    comment_id: BeatmapsetCommentId {
-                        map_discussion_id: None,
-                        map_discussion_post_id: None,
-                        mapset_discussion_id: None,
-                        mapset_discussion_post_id: None,
-                    },
-                    old: Language::Any,
-                    new: Language::Polish,
-                },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::Nominate {
-                event_id: 5,
-                comment: BeatmapsetCommentNominate {
-                    modes: vec![
-                        GameMode::Osu,
-                        GameMode::Taiko,
-                        GameMode::Catch,
-                        GameMode::Mania,
-                    ],
-                },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::NsfwToggle {
-                event_id: 6,
-                comment: BeatmapsetCommentEdit {
-                    comment_id: BeatmapsetCommentId {
-                        map_discussion_id: None,
-                        map_discussion_post_id: None,
-                        mapset_discussion_id: None,
-                        mapset_discussion_post_id: None,
-                    },
-                    old: true,
-                    new: false,
-                },
-                created_at: get_date(),
-                user_id: 123456,
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::OwnerChange {
-                event_id: 9,
-                comment: BeatmapsetCommentOwnerChange {
-                    map_discussion_id: Some(0),
-                    map_discussion_post_id: Some(1),
-                    map_id: 123,
-                    version: "epic version".to_owned(),
-                    new_user_id: 98,
-                    new_username: "new name".into(),
-                },
-                created_at: get_date(),
-                user_id: 99,
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::Rank {
-                event_id: 7,
-                created_at: get_date(),
-                mapset: get_mapset_compact(),
-            },
-            BeatmapsetEvent::Qualify {
-                event_id: 8,
-                created_at: get_date(),
-                mapset: get_mapset_compact(),
-            },
-        ],
-        reviews_config: BeatmapsetReviewsConfig { max_blocks: 100 },
-        users: vec![get_user_compact()],
+            ],
+            reviews_config: BeatmapsetReviewsConfig { max_blocks: 100 },
+            users: vec![get_user_compact()],
+        }
     }
-}
 
-fn get_match() -> OsuMatch {
-    OsuMatch {
-        current_game_id: Some(3),
-        end_time: Some(get_date()),
-        events: vec![
-            MatchEvent::Create {
-                event_id: 0,
+    pub(super) fn get_match() -> OsuMatch {
+        OsuMatch {
+            current_game_id: Some(3),
+            end_time: Some(get_date()),
+            events: vec![
+                MatchEvent::Create {
+                    event_id: 0,
+                    timestamp: get_date(),
+                    user_id: Some(0),
+                },
+                MatchEvent::Joined {
+                    event_id: 1,
+                    timestamp: get_date(),
+                    user_id: 1,
+                },
+                MatchEvent::Left {
+                    event_id: 2,
+                    timestamp: get_date(),
+                    user_id: 1,
+                },
+                MatchEvent::HostChanged {
+                    event_id: 3,
+                    timestamp: get_date(),
+                    user_id: 0,
+                },
+                MatchEvent::Game {
+                    event_id: 4,
+                    game: Box::new(MatchGame {
+                        game_id: 0,
+                        start_time: get_date(),
+                        end_time: Some(get_date()),
+                        mode: GameMode::Osu,
+                        scoring_type: ScoringType::Score,
+                        team_type: TeamType::HeadToHead,
+                        mods: GameMods::Hidden | GameMods::HardRock,
+                        map: Some(get_map_compact()),
+                        scores: vec![get_match_score()],
+                    }),
+                    match_name: "other name".to_owned(),
+                    timestamp: get_date(),
+                },
+                MatchEvent::Disbanded {
+                    event_id: 5,
+                    timestamp: get_date(),
+                },
+            ],
+            first_event_id: 0,
+            latest_event_id: 1,
+            match_id: 0,
+            name: "A: B vs C".to_owned(),
+            start_time: get_date(),
+            users: {
+                let mut map = HashMap::new();
+                map.insert(3, get_user_compact());
+
+                map
+            },
+        }
+    }
+
+    pub(super) fn get_match_score() -> MatchScore {
+        MatchScore {
+            user_id: 123456,
+            accuracy: 99.5,
+            mods: GameMods::ScoreV2 | GameMods::Relax,
+            score: 12_345_678,
+            max_combo: 1000,
+            perfect: false,
+            statistics: ScoreStatistics {
+                count_geki: 0,
+                count_300: 1,
+                count_katu: 2,
+                count_100: 3,
+                count_50: 4,
+                count_miss: 5,
+            },
+            slot: 0,
+            team: Team::Red,
+            pass: true,
+        }
+    }
+
+    pub(super) fn get_score() -> Score {
+        Score {
+            accuracy: 98.76,
+            ended_at: get_date(),
+            passed: true,
+            grade: Grade::A,
+            map_id: 123,
+            max_combo: 1234,
+            map: Some(get_map()),
+            mapset: Some(get_mapset_compact()),
+            mode: GameMode::Catch,
+            mods: GameMods::Hidden | GameMods::DoubleTime,
+            perfect: false,
+            pp: Some(456.78),
+            rank_country: Some(1),
+            rank_global: Some(10),
+            replay: Some(true),
+            score: 12_345_678,
+            score_id: Some(123_456_789_000),
+            statistics: ScoreStatistics {
+                count_geki: 1,
+                count_300: 1000,
+                count_katu: 2,
+                count_100: 300,
+                count_50: 200,
+                count_miss: 1,
+            },
+            user: Some(get_user_compact()),
+            user_id: 2,
+            weight: Some(ScoreWeight {
+                percentage: 1.0,
+                pp: 456.78,
+            }),
+        }
+    }
+
+    pub(super) fn get_seasonal_backgrounds() -> SeasonalBackgrounds {
+        SeasonalBackgrounds {
+            ends_at: get_date(),
+            backgrounds: vec![SeasonalBackground {
+                url: "https://www.bing.com".to_owned(),
+                artist: get_user_compact(),
+            }],
+        }
+    }
+
+    pub(super) fn get_spotlight() -> Spotlight {
+        Spotlight {
+            end_date: get_date(),
+            mode_specific: true,
+            name: "epic spotlight".to_owned(),
+            participant_count: Some(3),
+            spotlight_id: 2,
+            spotlight_type: "idk".to_owned(),
+            start_date: get_date(),
+        }
+    }
+
+    pub(super) fn get_user() -> User {
+        User {
+            avatar_url: String::new(),
+            comments_count: 0,
+            country: "belgiania".to_owned(),
+            country_code: "be".into(),
+            cover: UserCover {
+                custom_url: Some(String::new()),
+                url: String::new(),
+                id: Some(String::new()),
+            },
+            default_group: "default".to_owned(),
+            discord: Some(String::new()),
+            has_supported: true,
+            interests: Some(String::new()),
+            is_active: true,
+            is_bot: false,
+            is_deleted: false,
+            is_online: true,
+            is_supporter: false,
+            join_date: get_date(),
+            kudosu: UserKudosu {
+                available: 1,
+                total: 2,
+            },
+            last_visit: Some(get_date()),
+            location: Some(String::new()),
+            max_blocks: 0,
+            max_friends: 500,
+            mode: GameMode::Taiko,
+            occupation: Some(String::new()),
+            playstyle: Some(vec![Playstyle::Keyboard, Playstyle::Tablet]),
+            pm_friends_only: false,
+            forum_post_count: 0,
+            profile_color: Some(String::new()),
+            profile_order: vec![ProfilePage::Me, ProfilePage::TopRanks],
+            title: Some(String::new()),
+            title_url: Some(String::new()),
+            twitter: Some(String::new()),
+            user_id: 12345,
+            username: "bob".into(),
+            website: Some(String::new()),
+            account_history: Some(vec![AccountHistory {
+                id: Some(1),
+                description: Some("abc".to_owned()),
+                history_type: HistoryType::Note,
                 timestamp: get_date(),
-                user_id: Some(0),
-            },
-            MatchEvent::Joined {
-                event_id: 1,
+                seconds: 2,
+                permanent: false,
+            }]),
+            badges: Some(vec![Badge {
+                awarded_at: get_date(),
+                description: "big boi tourney".to_owned(),
+                image_url: String::new(),
+                url: String::new(),
+            }]),
+            beatmap_playcounts_count: Some(3),
+            favourite_mapset_count: Some(3),
+            follower_count: Some(2),
+            graveyard_mapset_count: Some(8),
+            groups: Some(vec![Group {
+                color: Some("#FFFFFF".to_owned()),
+                description: Some("epic group".to_owned()),
+                has_modes: true,
+                id: 1,
+                identifier: String::new(),
+                is_probationary: true,
+                modes: Some(vec![GameMode::Osu, GameMode::Mania]),
+                name: "group".to_owned(),
+                short_name: "g".to_owned(),
+            }]),
+            guest_mapset_count: Some(3),
+            highest_rank: Some(get_highest_rank()),
+            is_admin: Some(true),
+            is_bng: Some(false),
+            is_full_bn: Some(true),
+            is_gmt: Some(true),
+            is_limited_bn: Some(true),
+            is_moderator: Some(true),
+            is_nat: Some(true),
+            is_silenced: Some(true),
+            loved_mapset_count: Some(3),
+            mapping_follower_count: Some(5),
+            monthly_playcounts: Some(vec![MonthlyCount {
+                start_date: Date::from_ordinal_date(2017, 1).unwrap(),
+                count: 42,
+            }]),
+            page: Some(UserPage {
+                html: String::new(),
+                raw: String::new(),
+            }),
+            previous_usernames: Some(vec!["b0b".into()]),
+            rank_history: Some(vec![50, 40, 30, 35]),
+            ranked_mapset_count: Some(800),
+            replays_watched_counts: Some(vec![MonthlyCount {
+                start_date: Date::from_ordinal_date(2017, 1).unwrap(),
+                count: 42,
+            }]),
+            scores_best_count: Some(13),
+            scores_first_count: Some(13),
+            scores_recent_count: Some(13),
+            statistics: Some(get_user_stats()),
+            support_level: Some(3),
+            pending_mapset_count: Some(13),
+            medals: Some(vec![MedalCompact {
+                achieved_at: get_date(),
+                medal_id: 1,
+            }]),
+        }
+    }
+
+    pub(super) fn get_user_compact() -> UserCompact {
+        UserCompact {
+            avatar_url: String::new(),
+            country_code: "be".into(),
+            default_group: "default".to_owned(),
+            is_active: true,
+            is_bot: false,
+            is_deleted: false,
+            is_online: true,
+            is_supporter: true,
+            last_visit: Some(get_date()),
+            pm_friends_only: false,
+            profile_color: Some("#FFFFFF".to_owned()),
+            user_id: 12345,
+            username: "bob".into(),
+            account_history: Some(vec![AccountHistory {
+                id: Some(1),
+                description: None,
+                history_type: HistoryType::Note,
                 timestamp: get_date(),
-                user_id: 1,
+                seconds: 0,
+                permanent: true,
+            }]),
+            badges: Some(vec![Badge {
+                awarded_at: get_date(),
+                description: "big boi tourney".to_owned(),
+                image_url: String::new(),
+                url: String::new(),
+            }]),
+            beatmap_playcounts_count: Some(3),
+            country: Some("belgiania".to_owned()),
+            cover: Some(UserCover {
+                custom_url: None,
+                url: String::new(),
+                id: None,
+            }),
+            favourite_mapset_count: Some(34),
+            follower_count: Some(2),
+            graveyard_mapset_count: Some(34),
+            groups: Some(vec![Group {
+                color: Some("#FFFFFF".to_owned()),
+                description: Some("epic group".to_owned()),
+                has_modes: true,
+                id: 1,
+                identifier: String::new(),
+                is_probationary: true,
+                modes: Some(vec![GameMode::Osu, GameMode::Mania]),
+                name: "group".to_owned(),
+                short_name: "g".to_owned(),
+            }]),
+            guest_mapset_count: Some(3),
+            highest_rank: Some(get_highest_rank()),
+            is_admin: Some(true),
+            is_bng: Some(false),
+            is_full_bn: Some(true),
+            is_gmt: Some(true),
+            is_limited_bn: Some(true),
+            is_moderator: Some(false),
+            is_nat: Some(false),
+            is_silenced: Some(false),
+            loved_mapset_count: Some(34),
+            medals: Some(vec![MedalCompact {
+                achieved_at: get_date(),
+                medal_id: 1,
+            }]),
+            monthly_playcounts: Some(vec![MonthlyCount {
+                start_date: Date::from_ordinal_date(2017, 1).unwrap(),
+                count: 42,
+            }]),
+            page: Some(UserPage {
+                html: String::new(),
+                raw: String::new(),
+            }),
+            previous_usernames: Some(vec!["b0b".into()]),
+            rank_history: Some(vec![50, 40, 30, 35]),
+            ranked_mapset_count: Some(34),
+            replays_watched_counts: Some(vec![MonthlyCount {
+                start_date: Date::from_ordinal_date(2017, 1).unwrap(),
+                count: 42,
+            }]),
+            scores_best_count: Some(34),
+            scores_first_count: Some(34),
+            scores_recent_count: Some(34),
+            statistics: Some(get_user_stats()),
+            support_level: Some(1),
+            pending_mapset_count: Some(34),
+        }
+    }
+
+    pub(super) fn get_highest_rank() -> UserHighestRank {
+        UserHighestRank {
+            rank: 123,
+            updated_at: get_date(),
+        }
+    }
+
+    pub(super) fn get_user_stats() -> UserStatistics {
+        UserStatistics {
+            accuracy: 99.11,
+            country_rank: Some(1),
+            global_rank: Some(1),
+            grade_counts: GradeCounts {
+                ss: 1,
+                ssh: 2,
+                s: 3,
+                sh: 4,
+                a: 5,
             },
-            MatchEvent::Left {
-                event_id: 2,
-                timestamp: get_date(),
-                user_id: 1,
+            is_ranked: true,
+            level: UserLevel {
+                current: 101,
+                progress: 96,
             },
-            MatchEvent::HostChanged {
-                event_id: 3,
-                timestamp: get_date(),
-                user_id: 0,
+            max_combo: 6543,
+            playcount: 100_000,
+            playtime: 10_000_000,
+            pp: 9876.54,
+            ranked_score: 111_222_333_444,
+            replays_watched: 123,
+            total_hits: 123_456_789,
+            total_score: 111_222_333_444_555,
+        }
+    }
+
+    pub(super) fn get_map_attributes() -> Vec<BeatmapDifficultyAttributes> {
+        vec![
+            BeatmapDifficultyAttributes {
+                max_combo: 1,
+                stars: 2.0,
+                attrs: GameModeAttributes::Osu {
+                    ar: 5.55,
+                    od: 6.66,
+                    aim_difficulty: 4.44,
+                    flashlight_difficulty: 3.33,
+                    slider_factor: 2.22,
+                    speed_difficulty: 1.11,
+                },
             },
-            MatchEvent::Game {
-                event_id: 4,
-                game: Box::new(MatchGame {
-                    game_id: 0,
-                    start_time: get_date(),
-                    end_time: Some(get_date()),
-                    mode: GameMode::Osu,
-                    scoring_type: ScoringType::Score,
-                    team_type: TeamType::HeadToHead,
-                    mods: GameMods::Hidden | GameMods::HardRock,
-                    map: Some(get_map_compact()),
-                    scores: vec![get_match_score()],
-                }),
-                match_name: "other name".to_owned(),
-                timestamp: get_date(),
+            BeatmapDifficultyAttributes {
+                max_combo: 3,
+                stars: 4.0,
+                attrs: GameModeAttributes::Taiko {
+                    stamina_difficulty: 7.89,
+                    rhythm_difficulty: 4.56,
+                    colour_difficulty: 1.23,
+                    peak_difficulty: 999.99,
+                    great_hit_window: 10.0,
+                },
             },
-            MatchEvent::Disbanded {
-                event_id: 5,
-                timestamp: get_date(),
+            BeatmapDifficultyAttributes {
+                max_combo: 5,
+                stars: 6.0,
+                attrs: GameModeAttributes::Mania {
+                    great_hit_window: 1.0,
+                    score_multiplier: 3.0,
+                },
             },
-        ],
-        first_event_id: 0,
-        latest_event_id: 1,
-        match_id: 0,
-        name: "A: B vs C".to_owned(),
-        start_time: get_date(),
-        users: {
-            let mut map = HashMap::new();
-            map.insert(3, get_user_compact());
-
-            map
-        },
+        ]
     }
 }
 
-fn get_match_score() -> MatchScore {
-    MatchScore {
-        user_id: 123456,
-        accuracy: 99.5,
-        mods: GameMods::ScoreV2 | GameMods::Relax,
-        score: 12_345_678,
-        max_combo: 1000,
-        perfect: false,
-        statistics: ScoreStatistics {
-            count_geki: 0,
-            count_300: 1,
-            count_katu: 2,
-            count_100: 3,
-            count_50: 4,
-            count_miss: 5,
-        },
-        slot: 0,
-        team: Team::Red,
-        pass: true,
+#[cfg(feature = "serialize")]
+mod serde_tests {
+    use serde::{de::DeserializeOwned, Serialize};
+
+    use super::types::*;
+
+    fn roundtrip<T>(val: &T)
+    where
+        T: DeserializeOwned + Serialize + PartialEq + std::fmt::Debug,
+    {
+        let serialized =
+            serde_json::to_string(val).unwrap_or_else(|e| panic!("Failed to serialize: {}", e));
+
+        let deserialized: T = serde_json::from_str(&serialized)
+            .unwrap_or_else(|e| panic!("Failed to deserialize: {}\n{serialized}", e));
+
+        assert_eq!(val, &deserialized);
     }
-}
 
-fn get_score() -> Score {
-    Score {
-        accuracy: 98.76,
-        ended_at: get_date(),
-        passed: true,
-        grade: Grade::A,
-        map_id: 123,
-        max_combo: 1234,
-        map: Some(get_map()),
-        mapset: Some(get_mapset_compact()),
-        mode: GameMode::Catch,
-        mods: GameMods::Hidden | GameMods::DoubleTime,
-        perfect: false,
-        pp: Some(456.78),
-        rank_country: Some(1),
-        rank_global: Some(10),
-        replay: Some(true),
-        score: 12_345_678,
-        score_id: Some(123_456_789_000),
-        statistics: ScoreStatistics {
-            count_geki: 1,
-            count_300: 1000,
-            count_katu: 2,
-            count_100: 300,
-            count_50: 200,
-            count_miss: 1,
-        },
-        user: Some(get_user_compact()),
-        user_id: 2,
-        weight: Some(ScoreWeight {
-            percentage: 1.0,
-            pp: 456.78,
-        }),
+    #[test]
+    fn serde_beatmap() {
+        roundtrip(&get_map());
     }
-}
 
-fn get_seasonal_backgrounds() -> SeasonalBackgrounds {
-    SeasonalBackgrounds {
-        ends_at: get_date(),
-        backgrounds: vec![SeasonalBackground {
-            url: "https://www.bing.com".to_owned(),
-            artist: get_user_compact(),
-        }],
+    #[test]
+    fn serde_beatmap_attributes() {
+        roundtrip(&get_map_attributes());
     }
-}
 
-fn get_spotlight() -> Spotlight {
-    Spotlight {
-        end_date: get_date(),
-        mode_specific: true,
-        name: "epic spotlight".to_owned(),
-        participant_count: Some(3),
-        spotlight_id: 2,
-        spotlight_type: "idk".to_owned(),
-        start_date: get_date(),
+    #[test]
+    fn serde_beatmapset_events() {
+        roundtrip(&get_mapset_events());
     }
-}
 
-fn get_user() -> User {
-    User {
-        avatar_url: String::new(),
-        comments_count: 0,
-        country: "belgiania".to_owned(),
-        country_code: "be".into(),
-        cover: UserCover {
-            custom_url: Some(String::new()),
-            url: String::new(),
-            id: Some(String::new()),
-        },
-        default_group: "default".to_owned(),
-        discord: Some(String::new()),
-        has_supported: true,
-        interests: Some(String::new()),
-        is_active: true,
-        is_bot: false,
-        is_deleted: false,
-        is_online: true,
-        is_supporter: false,
-        join_date: get_date(),
-        kudosu: UserKudosu {
-            available: 1,
-            total: 2,
-        },
-        last_visit: Some(get_date()),
-        location: Some(String::new()),
-        max_blocks: 0,
-        max_friends: 500,
-        mode: GameMode::Taiko,
-        occupation: Some(String::new()),
-        playstyle: Some(vec![Playstyle::Keyboard, Playstyle::Tablet]),
-        pm_friends_only: false,
-        forum_post_count: 0,
-        profile_color: Some(String::new()),
-        profile_order: vec![ProfilePage::Me, ProfilePage::TopRanks],
-        title: Some(String::new()),
-        title_url: Some(String::new()),
-        twitter: Some(String::new()),
-        user_id: 12345,
-        username: "bob".into(),
-        website: Some(String::new()),
-        account_history: Some(vec![AccountHistory {
-            id: Some(1),
-            description: Some("abc".to_owned()),
-            history_type: HistoryType::Note,
-            timestamp: get_date(),
-            seconds: 2,
-            permanent: false,
-        }]),
-        badges: Some(vec![Badge {
-            awarded_at: get_date(),
-            description: "big boi tourney".to_owned(),
-            image_url: String::new(),
-            url: String::new(),
-        }]),
-        beatmap_playcounts_count: Some(3),
-        favourite_mapset_count: Some(3),
-        follower_count: Some(2),
-        graveyard_mapset_count: Some(8),
-        groups: Some(vec![Group {
-            color: Some("#FFFFFF".to_owned()),
-            description: Some("epic group".to_owned()),
-            has_modes: true,
-            id: 1,
-            identifier: String::new(),
-            is_probationary: true,
-            modes: Some(vec![GameMode::Osu, GameMode::Mania]),
-            name: "group".to_owned(),
-            short_name: "g".to_owned(),
-        }]),
-        guest_mapset_count: Some(3),
-        highest_rank: Some(get_highest_rank()),
-        is_admin: Some(true),
-        is_bng: Some(false),
-        is_full_bn: Some(true),
-        is_gmt: Some(true),
-        is_limited_bn: Some(true),
-        is_moderator: Some(true),
-        is_nat: Some(true),
-        is_silenced: Some(true),
-        loved_mapset_count: Some(3),
-        mapping_follower_count: Some(5),
-        monthly_playcounts: Some(vec![MonthlyCount {
-            start_date: Date::from_ordinal_date(2017, 1).unwrap(),
-            count: 42,
-        }]),
-        page: Some(UserPage {
-            html: String::new(),
-            raw: String::new(),
-        }),
-        previous_usernames: Some(vec!["b0b".into()]),
-        rank_history: Some(vec![50, 40, 30, 35]),
-        ranked_mapset_count: Some(800),
-        replays_watched_counts: Some(vec![MonthlyCount {
-            start_date: Date::from_ordinal_date(2017, 1).unwrap(),
-            count: 42,
-        }]),
-        scores_best_count: Some(13),
-        scores_first_count: Some(13),
-        scores_recent_count: Some(13),
-        statistics: Some(get_user_stats()),
-        support_level: Some(3),
-        pending_mapset_count: Some(13),
-        medals: Some(vec![MedalCompact {
-            achieved_at: get_date(),
-            medal_id: 1,
-        }]),
+    #[test]
+    fn serde_chart_rankings() {
+        roundtrip(&get_chart_rankings());
     }
-}
 
-fn get_user_compact() -> UserCompact {
-    UserCompact {
-        avatar_url: String::new(),
-        country_code: "be".into(),
-        default_group: "default".to_owned(),
-        is_active: true,
-        is_bot: false,
-        is_deleted: false,
-        is_online: true,
-        is_supporter: true,
-        last_visit: Some(get_date()),
-        pm_friends_only: false,
-        profile_color: Some("#FFFFFF".to_owned()),
-        user_id: 12345,
-        username: "bob".into(),
-        account_history: Some(vec![AccountHistory {
-            id: Some(1),
-            description: None,
-            history_type: HistoryType::Note,
-            timestamp: get_date(),
-            seconds: 0,
-            permanent: true,
-        }]),
-        badges: Some(vec![Badge {
-            awarded_at: get_date(),
-            description: "big boi tourney".to_owned(),
-            image_url: String::new(),
-            url: String::new(),
-        }]),
-        beatmap_playcounts_count: Some(3),
-        country: Some("belgiania".to_owned()),
-        cover: Some(UserCover {
-            custom_url: None,
-            url: String::new(),
-            id: None,
-        }),
-        favourite_mapset_count: Some(34),
-        follower_count: Some(2),
-        graveyard_mapset_count: Some(34),
-        groups: Some(vec![Group {
-            color: Some("#FFFFFF".to_owned()),
-            description: Some("epic group".to_owned()),
-            has_modes: true,
-            id: 1,
-            identifier: String::new(),
-            is_probationary: true,
-            modes: Some(vec![GameMode::Osu, GameMode::Mania]),
-            name: "group".to_owned(),
-            short_name: "g".to_owned(),
-        }]),
-        guest_mapset_count: Some(3),
-        highest_rank: Some(get_highest_rank()),
-        is_admin: Some(true),
-        is_bng: Some(false),
-        is_full_bn: Some(true),
-        is_gmt: Some(true),
-        is_limited_bn: Some(true),
-        is_moderator: Some(false),
-        is_nat: Some(false),
-        is_silenced: Some(false),
-        loved_mapset_count: Some(34),
-        medals: Some(vec![MedalCompact {
-            achieved_at: get_date(),
-            medal_id: 1,
-        }]),
-        monthly_playcounts: Some(vec![MonthlyCount {
-            start_date: Date::from_ordinal_date(2017, 1).unwrap(),
-            count: 42,
-        }]),
-        page: Some(UserPage {
-            html: String::new(),
-            raw: String::new(),
-        }),
-        previous_usernames: Some(vec!["b0b".into()]),
-        rank_history: Some(vec![50, 40, 30, 35]),
-        ranked_mapset_count: Some(34),
-        replays_watched_counts: Some(vec![MonthlyCount {
-            start_date: Date::from_ordinal_date(2017, 1).unwrap(),
-            count: 42,
-        }]),
-        scores_best_count: Some(34),
-        scores_first_count: Some(34),
-        scores_recent_count: Some(34),
-        statistics: Some(get_user_stats()),
-        support_level: Some(1),
-        pending_mapset_count: Some(34),
+    #[test]
+    fn serde_country_ranking() {
+        roundtrip(&get_country_ranking());
     }
-}
 
-fn get_highest_rank() -> UserHighestRank {
-    UserHighestRank {
-        rank: 123,
-        updated_at: get_date(),
+    #[test]
+    fn serde_forum_posts() {
+        roundtrip(&get_forum_posts());
     }
-}
 
-fn get_user_stats() -> UserStatistics {
-    UserStatistics {
-        accuracy: 99.11,
-        country_rank: Some(1),
-        global_rank: Some(1),
-        grade_counts: GradeCounts {
-            ss: 1,
-            ssh: 2,
-            s: 3,
-            sh: 4,
-            a: 5,
-        },
-        is_ranked: true,
-        level: UserLevel {
-            current: 101,
-            progress: 96,
-        },
-        max_combo: 6543,
-        playcount: 100_000,
-        playtime: 10_000_000,
-        pp: 9876.54,
-        ranked_score: 111_222_333_444,
-        replays_watched: 123,
-        total_hits: 123_456_789,
-        total_score: 111_222_333_444_555,
+    #[test]
+    fn serde_match() {
+        roundtrip(&get_match());
     }
-}
 
-fn get_map_attributes() -> Vec<BeatmapDifficultyAttributes> {
-    vec![
-        BeatmapDifficultyAttributes {
-            max_combo: 1,
-            stars: 2.0,
-            attrs: GameModeAttributes::Osu {
-                ar: 5.55,
-                od: 6.66,
-                aim_difficulty: 4.44,
-                flashlight_difficulty: 3.33,
-                slider_factor: 2.22,
-                speed_difficulty: 1.11,
-            },
-        },
-        BeatmapDifficultyAttributes {
-            max_combo: 3,
-            stars: 4.0,
-            attrs: GameModeAttributes::Taiko {
-                stamina_difficulty: 7.89,
-                rhythm_difficulty: 4.56,
-                colour_difficulty: 1.23,
-                peak_difficulty: 999.99,
-                great_hit_window: 10.0,
-            },
-        },
-        BeatmapDifficultyAttributes {
-            max_combo: 5,
-            stars: 6.0,
-            attrs: GameModeAttributes::Mania {
-                great_hit_window: 1.0,
-                score_multiplier: 3.0,
-            },
-        },
-    ]
-}
+    #[test]
+    fn serde_score() {
+        roundtrip(&get_score());
+    }
 
-#[test]
-fn serde_beatmap() {
-    ser_de(&get_map());
-}
+    #[test]
+    fn serde_seasonal_backgrounds() {
+        roundtrip(&get_seasonal_backgrounds());
+    }
 
-#[test]
-fn serde_beatmap_attributes() {
-    ser_de(&get_map_attributes());
-}
-
-#[test]
-fn serde_beatmapset_events() {
-    ser_de(&get_mapset_events());
-}
-
-#[test]
-fn serde_chart_rankings() {
-    ser_de(&get_chart_rankings());
-}
-
-#[test]
-fn serde_country_ranking() {
-    ser_de(&get_country_ranking());
-}
-
-#[test]
-fn serde_forum_posts() {
-    ser_de(&get_forum_posts());
-}
-
-#[test]
-fn serde_match() {
-    ser_de(&get_match());
-}
-
-#[test]
-fn serde_score() {
-    ser_de(&get_score());
-}
-
-#[test]
-fn serde_seasonal_backgrounds() {
-    ser_de(&get_seasonal_backgrounds());
-}
-
-#[test]
-fn serde_user() {
-    ser_de(&get_user());
+    #[test]
+    fn serde_user() {
+        roundtrip(&get_user());
+    }
 }
 
 #[cfg(feature = "rkyv")]
 mod rkyv_tests {
-    use std::fmt::Debug;
-
     use ::rkyv::{
         archived_root, ser::serializers::AllocSerializer, to_bytes, Archive, Deserialize,
         Infallible, Serialize,
     };
 
-    use super::*;
+    use super::types::*;
 
-    fn ser_de<T>(val: &T)
+    fn roundtrip<T>(val: &T)
     where
-        T: PartialEq + Debug + Archive + Serialize<AllocSerializer<512>>,
+        T: PartialEq + std::fmt::Debug + Archive + Serialize<AllocSerializer<512>>,
         <T as Archive>::Archived: Deserialize<T, Infallible>,
     {
         let bytes =
@@ -919,52 +927,52 @@ mod rkyv_tests {
 
     #[test]
     fn serde_beatmap() {
-        ser_de(&get_map());
+        roundtrip(&get_map());
     }
 
     #[test]
     fn serde_beatmap_attributes() {
-        ser_de(&get_map_attributes());
+        roundtrip(&get_map_attributes());
     }
 
     #[test]
     fn serde_beatmapset_events() {
-        ser_de(&get_mapset_events());
+        roundtrip(&get_mapset_events());
     }
 
     #[test]
     fn serde_chart_rankings() {
-        ser_de(&get_chart_rankings());
+        roundtrip(&get_chart_rankings());
     }
 
     #[test]
     fn serde_country_ranking() {
-        ser_de(&get_country_ranking());
+        roundtrip(&get_country_ranking());
     }
 
     // TODO
     // #[test]
     // fn serde_forum_posts() {
-    //     ser_de(&get_forum_posts());
+    //     roundtrip(&get_forum_posts());
     // }
 
     #[test]
     fn serde_match() {
-        ser_de(&get_match());
+        roundtrip(&get_match());
     }
 
     #[test]
     fn serde_score() {
-        ser_de(&get_score());
+        roundtrip(&get_score());
     }
 
     #[test]
     fn serde_seasonal_backgrounds() {
-        ser_de(&get_seasonal_backgrounds());
+        roundtrip(&get_seasonal_backgrounds());
     }
 
     #[test]
     fn serde_user() {
-        ser_de(&get_user());
+        roundtrip(&get_user());
     }
 }


### PR DESCRIPTION
Requires the `serialize` feature flag if types need to be serialized.
This reduces compile time and binary size if no serialization is required.