### PR TITLE
docs: remove comment about `Osu` being cloneable

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -111,10 +111,10 @@ impl OsuBuilder {
             token_loop_tx: Some(tx),
 
             #[cfg(feature = "cache")]
-            cache: Arc::new(DashMap::new()),
+            cache: Box::new(DashMap::new()),
 
             #[cfg(feature = "metrics")]
-            metrics: Arc::new(Metrics::new()),
+            metrics: Box::new(Metrics::new()),
         })
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,9 +40,9 @@ use {crate::metrics::Metrics, prometheus::IntCounterVec};
 pub struct Osu {
     pub(crate) inner: Arc<OsuRef>,
     #[cfg(feature = "cache")]
-    pub(crate) cache: Arc<DashMap<Username, u32>>,
+    pub(crate) cache: Box<DashMap<Username, u32>>,
     #[cfg(feature = "metrics")]
-    pub(crate) metrics: Arc<Metrics>,
+    pub(crate) metrics: Box<Metrics>,
     token_loop_tx: Option<Sender<()>>,
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,7 +37,6 @@ use {crate::prelude::Username, dashmap::DashMap};
 use {crate::metrics::Metrics, prometheus::IntCounterVec};
 
 /// The main osu client.
-/// Cheap to clone.
 pub struct Osu {
     pub(crate) inner: Arc<OsuRef>,
     #[cfg(feature = "cache")]


### PR DESCRIPTION
This fixes #5.

I did decide to wrap `cache` and `metrics` in a `Box` instead. `Osu::cache` has a size of `40 (0x28)` and `Osu::metrics` has a size of `288 (0x120)` (if vscode is to be believed).