### PR TITLE
refactor: encode query via serde_urlencoded

### DIFF
--- a/rosu-v2/Cargo.toml
+++ b/rosu-v2/Cargo.toml
@@ -28,9 +28,11 @@ leaky-bucket-lite = { version = "0.5" }
 log = { version = "0.4", default-features = false }
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 hyper-rustls = { version = "0.23", default-features = false, features = ["http1", "http2", "native-tokio"] }
+itoa = { version = "1.0.9" }
 paste = { version = "1.0", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "raw_value"] }
+serde_urlencoded = { version = "0.7.1" }
 smallstr = { version = "0.2", features = ["serde"] }
 thiserror = { version = "1.0" }
 time = { version = "0.3", features = ["formatting", "parsing"] }

--- a/rosu-v2/src/client/mod.rs
+++ b/rosu-v2/src/client/mod.rs
@@ -614,7 +614,7 @@ const API_VERSION: u32 = 20220705;
 
 impl OsuRef {
     async fn request_token(&self) -> OsuResult<TokenResponse> {
-        let mut body = Body::default();
+        let mut body = Body::new();
         body.push_without_quotes("client_id", self.client_id);
         body.push_with_quotes("client_secret", &self.client_secret);
 
@@ -672,7 +672,13 @@ impl OsuRef {
         #[cfg(feature = "metrics")]
         let start = std::time::Instant::now();
 
-        let url = format!("https://osu.ppy.sh/api/v2/{path}{query}");
+        let mut url = format!("https://osu.ppy.sh/api/v2/{path}");
+
+        if let Some(ref query) = query {
+            url.push('?');
+            url.push_str(query);
+        }
+
         let resp = self.raw(url, method, body).await?;
         let bytes = self.handle_status(resp).await?;
 

--- a/rosu-v2/src/model/comments_.rs
+++ b/rosu-v2/src/model/comments_.rs
@@ -1,7 +1,7 @@
 use super::{serde_, user_::User, Cursor};
 use crate::{prelude::Username, request::GetUser, Osu, OsuResult};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serializer};
 use std::fmt;
 use time::OffsetDateTime;
 
@@ -164,16 +164,27 @@ pub enum CommentSort {
     Top,
 }
 
-impl fmt::Display for CommentSort {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let sort = match self {
+impl CommentSort {
+    pub fn as_str(self) -> &'static str {
+        match self {
             Self::New => "new",
             Self::Old => "old",
             Self::Top => "top",
-        };
+        }
+    }
 
-        f.write_str(sort)
+    pub(crate) fn serialize_as_query<S: Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl fmt::Display for CommentSort {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/rosu-v2/src/model/mode.rs
+++ b/rosu-v2/src/model/mode.rs
@@ -26,6 +26,17 @@ pub enum GameMode {
     Mania = 3,
 }
 
+impl GameMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Osu => "osu",
+            Self::Taiko => "taiko",
+            Self::Catch => "fruits",
+            Self::Mania => "mania",
+        }
+    }
+}
+
 impl From<u8> for GameMode {
     #[inline]
     fn from(mode: u8) -> Self {
@@ -49,12 +60,7 @@ impl Default for GameMode {
 impl fmt::Display for GameMode {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Osu => f.write_str("osu"),
-            Self::Taiko => f.write_str("taiko"),
-            Self::Catch => f.write_str("fruits"),
-            Self::Mania => f.write_str("mania"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/rosu-v2/src/model/ranking_.rs
+++ b/rosu-v2/src/model/ranking_.rs
@@ -516,17 +516,14 @@ pub(crate) enum RankingType {
     Score,
 }
 
-impl fmt::Display for RankingType {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kind = match self {
+impl RankingType {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
             Self::Charts => "charts",
             Self::Country => "country",
             Self::Performance => "performance",
             Self::Score => "score",
-        };
-
-        f.write_str(kind)
+        }
     }
 }
 

--- a/rosu-v2/src/request/news.rs
+++ b/rosu-v2/src/request/news.rs
@@ -1,16 +1,22 @@
 use crate::{
     model::{news_::News, Cursor},
-    request::{Pending, Query, Request},
+    request::{serialize::maybe_cursor, Pending, Query, Request},
     routing::Route,
     Osu,
 };
 
+use serde::Serialize;
+
 /// Get a [`News`](crate::model::news::News) struct.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Serialize)]
 pub struct GetNews<'a> {
+    #[serde(skip)]
     fut: Option<Pending<'a, News>>,
+    #[serde(skip)]
     osu: &'a Osu,
     news: Option<()>, // TODO
+    #[serde(flatten, serialize_with = "maybe_cursor")]
     cursor: Option<Cursor>,
 }
 
@@ -28,25 +34,20 @@ impl<'a> GetNews<'a> {
     // TODO
     // #[inline]
     // pub fn news(mut self, news: ()) -> Self {
-    //     self.news.replace(news);
+    //     self.news = Some(news);
 
     //     self
     // }
 
     #[inline]
     pub(crate) fn cursor(mut self, cursor: Cursor) -> Self {
-        self.cursor.replace(cursor);
+        self.cursor = Some(cursor);
 
         self
     }
 
     fn start(&mut self) -> Pending<'a, News> {
-        let mut query = Query::new();
-
-        if let Some(cursor) = self.cursor.take() {
-            cursor.push_to_query(&mut query);
-        }
-
+        let query = Query::encode(self);
         let req = Request::with_query(Route::GetNews { news: self.news }, query);
 
         Box::pin(self.osu.request(req))

--- a/rosu-v2/src/request/replay.rs
+++ b/rosu-v2/src/request/replay.rs
@@ -67,10 +67,7 @@ impl<'a> GetReplay<'a> {
 
     fn start(&mut self) -> Pending<'a, Replay> {
         let fut = self.inner.take().unwrap().map(|res| {
-            let bytes = res?;
-            let replay = Replay::from_bytes(&bytes)?;
-
-            Ok(replay)
+            res.and_then(|bytes| Replay::from_bytes(&bytes).map_err(crate::error::OsuError::from))
         });
 
         Box::pin(fut)

--- a/rosu-v2/src/request/serialize.rs
+++ b/rosu-v2/src/request/serialize.rs
@@ -1,0 +1,97 @@
+use crate::model::{Cursor, GameMode};
+use crate::prelude::{CommentSort, GameModsIntermode};
+
+use crate::request::UserId;
+use serde::ser::{SerializeMap, Serializer};
+use std::cmp;
+
+fn maybe<F, T, S>(option: &Option<T>, serializer: S, f: F) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    F: FnOnce(&T, S) -> Result<S::Ok, S::Error>,
+{
+    match option {
+        Some(some) => f(some, serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub(crate) fn maybe_mode_as_str<S: Serializer>(
+    mode: &Option<GameMode>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(mode, serializer, mode_as_str)
+}
+
+pub(crate) fn mode_as_str<S: Serializer>(
+    mode: &GameMode,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(mode.as_str())
+}
+
+pub(crate) fn maybe_mods_as_list<S: Serializer>(
+    mods: &Option<GameModsIntermode>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(mods, serializer, mods_as_list)
+}
+
+pub(crate) fn mods_as_list<S: Serializer>(
+    mods: &GameModsIntermode,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let mut map = serializer.serialize_map(Some(cmp::max(mods.len(), 1)))?;
+
+    if mods.is_empty() {
+        map.serialize_entry("mods[]", "NM")?;
+    } else {
+        for m in mods.iter() {
+            map.serialize_entry("mods[]", m.acronym().as_str())?;
+        }
+    }
+
+    map.end()
+}
+
+pub(crate) fn maybe_cursor<S: Serializer>(
+    cursor: &Option<Cursor>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(cursor, serializer, Cursor::serialize_as_query)
+}
+
+pub(crate) fn maybe_comment_sort<S: Serializer>(
+    sort: &Option<CommentSort>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(sort, serializer, CommentSort::serialize_as_query)
+}
+
+pub(crate) fn maybe_user_id_type<S: Serializer>(
+    user_id: &Option<UserId>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(user_id, serializer, user_id_type)
+}
+
+pub(crate) fn user_id_type<S: Serializer>(
+    user_id: &UserId,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match user_id {
+        UserId::Id(_) => serializer.serialize_str("id"),
+        UserId::Name(_) => serializer.serialize_str("username"),
+    }
+}
+
+pub(crate) fn maybe_bool_as_u8<S: Serializer>(
+    b: &Option<bool>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    maybe(b, serializer, bool_as_u8)
+}
+
+pub(crate) fn bool_as_u8<S: Serializer>(b: &bool, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_u8(if *b { 1 } else { 0 })
+}

--- a/rosu-v2/src/routing.rs
+++ b/rosu-v2/src/routing.rs
@@ -94,29 +94,29 @@ impl Route {
                 (Method::POST, format!("beatmaps/{map_id}/attributes").into())
             }
             Self::GetBeatmapScores { map_id } => {
-                (Method::GET, format!("beatmaps/{}/scores", map_id).into())
+                (Method::GET, format!("beatmaps/{map_id}/scores").into())
             }
             Self::GetBeatmapUserScore { map_id, user_id } => (
                 Method::GET,
-                format!("beatmaps/{}/scores/users/{}", map_id, user_id).into(),
+                format!("beatmaps/{map_id}/scores/users/{user_id}").into(),
             ),
             Self::GetBeatmapUserScores { map_id, user_id } => (
                 Method::GET,
-                format!("beatmaps/{}/scores/users/{}/all", map_id, user_id).into(),
+                format!("beatmaps/{map_id}/scores/users/{user_id}/all").into(),
             ),
             Self::GetBeatmapset { mapset_id } => {
-                (Method::GET, format!("beatmapsets/{}", mapset_id).into())
+                (Method::GET, format!("beatmapsets/{mapset_id}").into())
             }
             Self::GetBeatmapsetFromMapId => (Method::GET, "beatmapsets/lookup".into()),
             Self::GetBeatmapsetEvents => (Method::GET, "beatmapsets/events".into()),
             Self::GetBeatmapsetSearch => (Method::GET, "beatmapsets/search".into()),
             Self::GetComments => (Method::GET, "comments".into()),
             Self::GetForumPosts { topic_id } => {
-                (Method::GET, format!("forums/topics/{}", topic_id).into())
+                (Method::GET, format!("forums/topics/{topic_id}").into())
             }
             Self::GetMatch { match_id } => {
                 let path = match match_id {
-                    Some(id) => format!("matches/{}", id).into(),
+                    Some(id) => format!("matches/{id}").into(),
                     None => "matches".into(),
                 };
 
@@ -132,7 +132,7 @@ impl Route {
             }
             Self::GetOwnData { mode } => {
                 let path = match mode {
-                    Some(mode) => format!("me/{}", mode).into(),
+                    Some(mode) => format!("me/{mode}").into(),
                     None => "me".into(),
                 };
 
@@ -140,47 +140,47 @@ impl Route {
             }
             Self::GetRankings { mode, ranking_type } => (
                 Method::GET,
-                format!("rankings/{}/{}", mode, ranking_type).into(),
+                format!("rankings/{mode}/{}", ranking_type.as_str()).into(),
             ),
             Self::GetRecentEvents { user_id } => (
                 Method::GET,
-                format!("users/{}/recent_activity", user_id).into(),
+                format!("users/{user_id}/recent_activity").into(),
             ),
             Self::GetReplay { mode, score_id } => (
                 Method::GET,
-                format!("scores/{}/{}/download", mode, score_id).into(),
+                format!("scores/{mode}/{score_id}/download").into(),
             ),
             Self::GetScore { mode, score_id } => {
-                (Method::GET, format!("scores/{}/{}", mode, score_id).into())
+                (Method::GET, format!("scores/{mode}/{score_id}").into())
             }
             Self::GetSeasonalBackgrounds => (Method::GET, "seasonal-backgrounds".into()),
             Self::GetSpotlights => (Method::GET, "spotlights".into()),
             Self::GetUser { user_id, mode } => {
-                let mut path = format!("users/{}", user_id);
+                let mut path = format!("users/{user_id}");
 
                 if let Some(mode) = mode {
-                    let _ = write!(path, "/{}", mode);
+                    let _ = write!(path, "/{mode}");
                 }
 
                 (Method::GET, path.into())
             }
             Self::GetUserBeatmapsets { user_id, map_type } => (
                 Method::GET,
-                format!("users/{}/beatmapsets/{}", user_id, map_type).into(),
+                format!("users/{user_id}/beatmapsets/{map_type}").into(),
             ),
             Self::GetUserKudosu { user_id } => {
-                (Method::GET, format!("users/{}/kudosu", user_id).into())
+                (Method::GET, format!("users/{user_id}/kudosu").into())
             }
             Self::GetUserScores {
                 user_id,
                 score_type,
             } => (
                 Method::GET,
-                format!("users/{}/scores/{}", user_id, score_type).into(),
+                format!("users/{user_id}/scores/{}", score_type.as_str()).into(),
             ),
             Self::GetUsers => (Method::GET, "users".into()),
             Self::GetWikiPage { locale, page } => {
-                let mut path = format!("wiki/{}/", locale);
+                let mut path = format!("wiki/{locale}/");
 
                 if let Some(page) = page {
                     path.push_str(&page);


### PR DESCRIPTION
Adds a `Serialize` implementation for request types that create a query.
Also adds a new `as_str` method to some types which returns the result of the `Display` implementation.