### PR TITLE
perf!: box big structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Metrics are now recorded using the [`metrics`](https://github.com/metrics-rs/metrics/tree/main/metrics) crate instead of prometheus directly.
     That means they're no longer exposed through a method, but are recorded in the global metrics registry instead.
     You can install a global metrics registry e.g. through the [metrics-exporter-prometheus](https://github.com/metrics-rs/metrics/tree/main/metrics-exporter-prometheus) crate.
+  - Most fields of (optional) `User(Extended)`, `Beatmap(Extended)`, and `Beatmapset(Extended)` are now wrapped in a `Box`.
 
 - __Fixes__:
   - Fixed deserializing `FailTimes` for `Beatmap` and `BeatmapExtended`

--- a/rosu-v2/src/model/beatmap_.rs
+++ b/rosu-v2/src/model/beatmap_.rs
@@ -53,7 +53,7 @@ pub struct BeatmapExtended {
     #[serde(rename = "id")]
     pub map_id: u32,
     #[serde(rename = "beatmapset", skip_serializing_if = "Option::is_none")]
-    pub mapset: Option<BeatmapsetExtended>,
+    pub mapset: Option<Box<BeatmapsetExtended>>,
     #[serde(rename = "beatmapset_id")]
     pub mapset_id: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -111,7 +111,7 @@ pub struct Beatmap {
     #[serde(rename = "id")]
     pub map_id: u32,
     #[serde(rename = "beatmapset", skip_serializing_if = "Option::is_none")]
-    pub mapset: Option<Beatmapset>,
+    pub mapset: Option<Box<Beatmapset>>,
     #[serde(rename = "beatmapset_id")]
     pub mapset_id: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -141,7 +141,7 @@ impl From<BeatmapExtended> for Beatmap {
             creator_id: map.creator_id,
             fail_times: map.fail_times,
             map_id: map.map_id,
-            mapset: map.mapset.map(|ms| ms.into()),
+            mapset: map.mapset.map(|ms| Box::new((*ms).into())),
             mapset_id: map.mapset_id,
             max_combo: map.max_combo,
             mode: map.mode,
@@ -243,7 +243,7 @@ pub struct BeatmapsetExtended {
         deserialize_with = "deser_mapset_user",
         skip_serializing_if = "Option::is_none"
     )]
-    pub creator: Option<User>,
+    pub creator: Option<Box<User>>,
     #[serde(rename = "creator")]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::UsernameWrapper))]
     pub creator_name: Username,
@@ -312,11 +312,11 @@ pub struct BeatmapsetExtended {
 
 // Deserialize the creator's `UserCompact` manually for edge cases
 // like mapset /s/3 where the user was deleted
-fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<User>, D::Error> {
+fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Box<User>>, D::Error> {
     struct MapsetUserVisitor;
 
     impl<'de> Visitor<'de> for MapsetUserVisitor {
-        type Value = Option<User>;
+        type Value = Option<Box<User>>;
 
         fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
             f.write_str("an optional UserCompact")
@@ -396,7 +396,7 @@ fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<User>, D:
                 profile_color.ok_or_else(|| Error::missing_field("profile_color"))?;
             let username = username.ok_or_else(|| Error::missing_field("username"))?;
 
-            Ok(Some(User {
+            Ok(Some(Box::new(User {
                 avatar_url,
                 country_code,
                 default_group,
@@ -443,7 +443,7 @@ fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<User>, D:
                 statistics: None,
                 support_level: None,
                 pending_mapset_count: None,
-            }))
+            })))
         }
 
         #[inline]
@@ -743,7 +743,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     GenreEdit {
@@ -755,7 +755,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     IssueReopen {
         #[serde(rename = "id")]
@@ -766,7 +766,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     IssueResolve {
@@ -778,7 +778,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     KudosuDeny {
@@ -789,7 +789,7 @@ pub enum BeatmapsetEvent {
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         created_at: OffsetDateTime,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     KudosuGain {
@@ -801,7 +801,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     KudosuLost {
@@ -813,7 +813,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
         discussion: BeatmapsetDiscussion,
     },
     LanguageEdit {
@@ -825,7 +825,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     Love {
         #[serde(rename = "id")]
@@ -835,7 +835,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     Nominate {
         #[serde(rename = "id")]
@@ -846,7 +846,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     NsfwToggle {
         #[serde(rename = "id")]
@@ -857,7 +857,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     #[serde(rename = "beatmap_owner_change")]
     OwnerChange {
@@ -869,7 +869,7 @@ pub enum BeatmapsetEvent {
         created_at: OffsetDateTime,
         user_id: u32,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     Rank {
         #[serde(rename = "id")]
@@ -878,7 +878,7 @@ pub enum BeatmapsetEvent {
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         created_at: OffsetDateTime,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     Qualify {
         #[serde(rename = "id")]
@@ -887,7 +887,7 @@ pub enum BeatmapsetEvent {
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         created_at: OffsetDateTime,
         #[serde(rename = "beatmapset")]
-        mapset: Beatmapset,
+        mapset: Box<Beatmapset>,
     },
     TagsEdit {
         #[serde(rename = "id")]
@@ -896,7 +896,7 @@ pub enum BeatmapsetEvent {
         #[serde(with = "serde_::datetime")]
         #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
         created_at: OffsetDateTime,
-        beatmapset: Beatmapset,
+        beatmapset: Box<Beatmapset>,
     },
 }
 
@@ -1478,11 +1478,11 @@ mod hundred_items {
 pub struct MostPlayedMap {
     pub count: usize,
     #[serde(rename = "beatmap")]
-    pub map: Beatmap,
+    pub map: Box<Beatmap>,
     #[serde(rename = "beatmap_id")]
     pub map_id: u32,
     #[serde(rename = "beatmapset")]
-    pub mapset: Beatmapset,
+    pub mapset: Box<Beatmapset>,
 }
 
 impl PartialEq for MostPlayedMap {

--- a/rosu-v2/src/model/matches_.rs
+++ b/rosu-v2/src/model/matches_.rs
@@ -331,7 +331,7 @@ pub struct MatchGame {
     /// [`Beatmap`](crate::model::beatmap::Beatmap) of the game;
     /// `None` if the map was deleted
     #[cfg_attr(feature = "serialize", serde(rename = "beatmap"))]
-    pub map: Option<Beatmap>,
+    pub map: Option<Box<Beatmap>>,
     pub scores: Vec<MatchScore>,
 }
 
@@ -350,7 +350,7 @@ impl<'de> Deserialize<'de> for MatchGame {
             team_type: TeamType,
             mods: Box<RawValue>,
             #[serde(rename = "beatmap")]
-            map: Option<Beatmap>,
+            map: Option<Box<Beatmap>>,
             scores: Vec<MatchScore>,
         }
 

--- a/rosu-v2/src/model/score_.rs
+++ b/rosu-v2/src/model/score_.rs
@@ -60,12 +60,12 @@ pub struct Score {
         feature = "serialize",
         serde(rename = "beatmap", skip_serializing_if = "Option::is_none")
     )]
-    pub map: Option<BeatmapExtended>,
+    pub map: Option<Box<BeatmapExtended>>,
     #[cfg_attr(
         feature = "serialize",
         serde(rename = "beatmapset", skip_serializing_if = "Option::is_none")
     )]
-    pub mapset: Option<Beatmapset>,
+    pub mapset: Option<Box<Beatmapset>>,
     pub mode: GameMode,
     pub mods: GameMods,
     pub perfect: bool,
@@ -81,7 +81,7 @@ pub struct Score {
     pub score_id: Option<u64>,
     pub statistics: ScoreStatistics,
     #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
-    pub user: Option<User>,
+    pub user: Option<Box<User>>,
     pub user_id: u32,
     #[cfg_attr(feature = "serialize", serde(skip_serializing_if = "Option::is_none"))]
     pub weight: Option<ScoreWeight>,
@@ -102,9 +102,9 @@ impl<'de> Deserialize<'de> for Score {
             map_id: u32,
             max_combo: u32,
             #[serde(rename = "beatmap")]
-            map: Option<BeatmapExtended>,
+            map: Option<Box<BeatmapExtended>>,
             #[serde(rename = "beatmapset")]
-            mapset: Option<Beatmapset>,
+            mapset: Option<Box<Beatmapset>>,
             #[serde(alias = "ruleset_id")]
             mode: GameMode,
             mods: Box<RawValue>,
@@ -119,7 +119,7 @@ impl<'de> Deserialize<'de> for Score {
             #[serde(rename = "best_id")]
             score_id: Option<u64>,
             statistics: ScoreStatistics,
-            user: Option<User>,
+            user: Option<Box<User>>,
             user_id: u32,
             weight: Option<ScoreWeight>,
         }

--- a/rosu-v2/tests/requests.rs
+++ b/rosu-v2/tests/requests.rs
@@ -212,7 +212,7 @@ async fn beatmapset_search() -> Result<()> {
         search_result.total,
     );
 
-    let search_result = search_result.get_next(&*osu).await.unwrap()?;
+    let search_result = search_result.get_next(&osu).await.unwrap()?;
 
     println!(
         "Received next search result containing {} out of {} mapsets",

--- a/rosu-v2/tests/serde.rs
+++ b/rosu-v2/tests/serde.rs
@@ -101,7 +101,7 @@ mod types {
             can_be_hyped: true,
             converts: Some(vec![]),
             covers: get_mapset_covers(),
-            creator: Some(get_user_compact()),
+            creator: Some(Box::new(get_user_compact())),
             creator_name: "god".into(),
             creator_id: 2,
             description: Some("description".to_owned()),
@@ -160,7 +160,7 @@ mod types {
             is_scoreable: true,
             last_updated: get_date(),
             map_id: 123456,
-            mapset: Some(get_mapset()),
+            mapset: Some(Box::new(get_mapset())),
             mapset_id: 12345,
             max_combo: Some(1750),
             mode: GameMode::Osu,
@@ -182,7 +182,7 @@ mod types {
             creator_id: 456,
             fail_times: None,
             map_id: 123456,
-            mapset: Some(get_mapset_compact()),
+            mapset: Some(Box::new(get_mapset_compact())),
             mapset_id: 2345,
             max_combo: Some(1000),
             mode: GameMode::Catch,
@@ -264,7 +264,7 @@ mod types {
                         mapset_discussion_post_id: None,
                     },
                     created_at: get_date(),
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                     user_id: 123456,
                     discussion: get_mapset_discussion(),
                 },
@@ -282,7 +282,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::IssueReopen {
                     event_id: 1,
@@ -294,7 +294,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                     discussion: get_mapset_discussion(),
                 },
                 BeatmapsetEvent::IssueResolve {
@@ -307,7 +307,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                     discussion: get_mapset_discussion(),
                 },
                 BeatmapsetEvent::KudosuDeny {
@@ -319,7 +319,7 @@ mod types {
                         mapset_discussion_post_id: Some(3),
                     },
                     created_at: get_date(),
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                     discussion: get_mapset_discussion(),
                 },
                 BeatmapsetEvent::KudosuGain {
@@ -342,7 +342,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                     discussion: get_mapset_discussion(),
                 },
                 BeatmapsetEvent::LanguageEdit {
@@ -359,7 +359,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::Nominate {
                     event_id: 5,
@@ -373,7 +373,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::NsfwToggle {
                     event_id: 6,
@@ -389,7 +389,7 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 123456,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::OwnerChange {
                     event_id: 9,
@@ -403,17 +403,17 @@ mod types {
                     },
                     created_at: get_date(),
                     user_id: 99,
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::Rank {
                     event_id: 7,
                     created_at: get_date(),
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
                 BeatmapsetEvent::Qualify {
                     event_id: 8,
                     created_at: get_date(),
-                    mapset: get_mapset_compact(),
+                    mapset: Box::new(get_mapset_compact()),
                 },
             ],
             reviews_config: BeatmapsetReviewsConfig { max_blocks: 100 },
@@ -463,7 +463,7 @@ mod types {
                         ]
                         .into_iter()
                         .collect(),
-                        map: Some(get_map_compact()),
+                        map: Some(Box::new(get_map_compact())),
                         scores: vec![get_match_score()],
                     }),
                     match_name: "other name".to_owned(),
@@ -518,8 +518,8 @@ mod types {
             grade: Grade::A,
             map_id: 123,
             max_combo: 1234,
-            map: Some(get_map()),
-            mapset: Some(get_mapset_compact()),
+            map: Some(Box::new(get_map())),
+            mapset: Some(Box::new(get_mapset_compact())),
             mode: GameMode::Catch,
             mods: [
                 GameMod::DifficultyAdjustCatch(DifficultyAdjustCatch {
@@ -549,7 +549,7 @@ mod types {
                 count_50: 200,
                 count_miss: 1,
             },
-            user: Some(get_user_compact()),
+            user: Some(Box::new(get_user_compact())),
             user_id: 2,
             weight: Some(ScoreWeight {
                 percentage: 1.0,


### PR DESCRIPTION
Boxes most fields of (optional) type `User(Extended)`, `Beatmap(Extended)`, and `Beatmapset(Extended)`.
This causes more allocations but reduces struct sizes significantly and thus reduce the allocation sizes.

```
___Without boxes:___
Score: 2840
Beatmap: 512
BeatmapExtended: 1584
Beatmapset: 408
BeatmapsetExtended: 1376

___With boxes:___
Score: 168
Beatmap: 112
BeatmapExtended: 216
Beatmapset: 408
BeatmapsetExtended: 680
```