### PR TITLE
feat: fetching legacy score data

### DIFF
--- a/rosu-v2/src/request/mod.rs
+++ b/rosu-v2/src/request/mod.rs
@@ -55,9 +55,12 @@ pub(crate) struct Request {
     pub query: Option<String>,
     pub route: Route,
     pub body: Body,
+    pub api_version: u32,
 }
 
 impl Request {
+    const API_VERSION: u32 = 20220705;
+
     fn new(route: Route) -> Self {
         Self::with_body(route, Body::new())
     }
@@ -67,6 +70,7 @@ impl Request {
             query: None,
             route,
             body,
+            api_version: Self::API_VERSION,
         }
     }
 
@@ -79,7 +83,12 @@ impl Request {
             query: Some(query),
             route,
             body,
+            api_version: Self::API_VERSION,
         }
+    }
+
+    fn api_version(&mut self, api_version: u32) {
+        self.api_version = api_version;
     }
 }
 

--- a/rosu-v2/tests/requests.rs
+++ b/rosu-v2/tests/requests.rs
@@ -499,6 +499,24 @@ async fn user_scores() -> Result<()> {
 }
 
 #[tokio::test]
+async fn user_scores_legacy() -> Result<()> {
+    let scores = OSU
+        .get()
+        .await?
+        .user_scores(BADEWANNE3)
+        .mode(GameMode::Taiko)
+        .limit(9)
+        .offset(1)
+        .best()
+        .legacy_scores(true)
+        .await?;
+
+    assert_eq!(scores.len(), 9);
+
+    Ok(())
+}
+
+#[tokio::test]
 #[ignore = "currently unavailable"]
 async fn users() -> Result<()> {
     #[allow(deprecated)]


### PR DESCRIPTION
Adds `legacy_scores` methods to endpoints that retrieve scores. If specified as `true`, the returned scores will contain legacy data, i.e. a different grade and score calculation, legacy mods, a different score kind, and less populated statistics.