### PR TITLE
feat!: undeprecate multiple users endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ when creating the client in order to make requests on behalf of the authenticate
 The following endpoints are currently supported:
 
 - `beatmaps/lookup`: A specific beatmap including its beatmapset
-- `beatmaps`: Up to 50 beatmaps at once including their beatmapsets.
+- `beatmaps`: Up to 50 beatmaps at once including their beatmapsets
 - `beatmaps/{map_id}/attributes`: The difficulty attributes of a beatmap
 - `beatmaps/{map_id}/scores`: The global score leaderboard for a beatmap
 - `beatmaps/{map_id}/scores/users/{user_id}[/all]`: Get (all) top score(s) of a user on a beatmap. Defaults to the play with the **max score**, not pp
@@ -48,6 +48,7 @@ The following endpoints are currently supported:
 - `users/{user_id}/{beatmapsets/{map_type}`: List of beatmapsets either created, favourited, or most played by the user
 - `users/{user_id}/kudosu`: A user's recent kudosu transfers
 - `users/{user_id}/scores/{score_type}`: Either top, recent, pinned, or global #1 scores of a user
+- `users`: Up to 50 users at once including statistics for all modes
 - `wiki/{locale}[/{path}]`: The general wiki page or a specific topic if the path is specified
 
 The api itself provides a bunch more endpoints which are not yet implemented because they're really niche and/or missing any documentation.

--- a/rosu-v2/src/client/mod.rs
+++ b/rosu-v2/src/client/mod.rs
@@ -522,9 +522,11 @@ impl Osu {
     }
 
     /// Get a vec of [`User`](crate::model::user::User).
-    #[deprecated = "The API currently doesn't allow this endpoint for public use"]
     #[inline]
-    pub fn users(&self, user_ids: &[u32]) -> GetUsers<'_> {
+    pub fn users<I>(&self, user_ids: I) -> GetUsers<'_>
+    where
+        I: IntoIterator<Item = u32>,
+    {
         GetUsers::new(self, user_ids)
     }
 

--- a/rosu-v2/src/lib.rs
+++ b/rosu-v2/src/lib.rs
@@ -24,7 +24,7 @@
 //! The following endpoints are currently supported:
 //!
 //! - `beatmaps/lookup`: A specific beatmap including its beatmapset
-//! - `beatmaps`: Up to 50 beatmaps at once including their beatmapsets.
+//! - `beatmaps`: Up to 50 beatmaps at once including their beatmapsets
 //! - `beatmaps/{map_id}/attributes`: The difficulty attributes of a beatmap
 //! - `beatmaps/{map_id}/scores`: The global score leaderboard for a beatmap
 //! - `beatmaps/{map_id}/scores/users/{user_id}[/all]`: Get (all) top score(s) of a user on a beatmap. Defaults to the play with the __max score__, not pp
@@ -46,6 +46,7 @@
 //! - `users/{user_id}/{beatmapsets/{map_type}`: List of beatmapsets either created, favourited, or most played by the user
 //! - `users/{user_id}/kudosu`: A user's recent kudosu transfers
 //! - `users/{user_id}/scores/{score_type}`: Either top, recent, pinned, or global #1 scores of a user
+//! - `users`: Up to 50 users at once including statistics for all modes
 //! - `wiki/{locale}[/{path}]`: The general wiki page or a specific topic if the path is specified
 //!
 //! The api itself provides a bunch more endpoints which are not yet implemented because they're really niche and/or missing any documentation.

--- a/rosu-v2/src/model/beatmap_.rs
+++ b/rosu-v2/src/model/beatmap_.rs
@@ -441,6 +441,7 @@ fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Box<User>
                 scores_first_count: None,
                 scores_recent_count: None,
                 statistics: None,
+                statistics_modes: None,
                 support_level: None,
                 pending_mapset_count: None,
             })))

--- a/rosu-v2/src/model/mod.rs
+++ b/rosu-v2/src/model/mod.rs
@@ -255,7 +255,8 @@ pub mod user {
     pub use super::user_::{
         AccountHistory, Badge, CountryCode, GradeCounts, Group, HistoryType, Medal, MedalCompact,
         MonthlyCount, Playstyle, ProfileBanner, ProfilePage, User, UserCover, UserExtended,
-        UserHighestRank, UserKudosu, UserLevel, UserPage, UserStatistics, Username,
+        UserHighestRank, UserKudosu, UserLevel, UserPage, UserStatistics, UserStatisticsModes,
+        Username,
     };
 }
 
@@ -335,11 +336,12 @@ pub mod rkyv {
         AccountHistoryResolver, ArchivedAccountHistory, ArchivedBadge, ArchivedGroup,
         ArchivedMedal, ArchivedMedalCompact, ArchivedMonthlyCount, ArchivedProfileBanner,
         ArchivedUser, ArchivedUserCover, ArchivedUserExtended, ArchivedUserHighestRank,
-        ArchivedUserPage, ArchivedUserStatistics, BadgeResolver, GradeCountsResolver,
-        GroupResolver, HistoryTypeResolver, MedalCompactResolver, MedalResolver,
-        MonthlyCountResolver, PlaystyleResolver, ProfileBannerResolver, ProfilePageResolver,
-        UserCoverResolver, UserExtendedResolver, UserHighestRankResolver, UserKudosuResolver,
-        UserLevelResolver, UserPageResolver, UserResolver, UserStatisticsResolver,
+        ArchivedUserPage, ArchivedUserStatistics, ArchivedUserStatisticsModes, BadgeResolver,
+        GradeCountsResolver, GroupResolver, HistoryTypeResolver, MedalCompactResolver,
+        MedalResolver, MonthlyCountResolver, PlaystyleResolver, ProfileBannerResolver,
+        ProfilePageResolver, UserCoverResolver, UserExtendedResolver, UserHighestRankResolver,
+        UserKudosuResolver, UserLevelResolver, UserPageResolver, UserResolver,
+        UserStatisticsModesResolver, UserStatisticsResolver,
     };
 
     pub use super::wiki_::{ArchivedWikiPage, WikiPageResolver};

--- a/rosu-v2/src/model/ranking_.rs
+++ b/rosu-v2/src/model/ranking_.rs
@@ -269,16 +269,16 @@ impl<'u> serde::Serialize for UserCompactBorrowed<'u> {
         s.serialize_field("replays_watched_by_others", &stats.replays_watched)?;
         s.serialize_field("total_hits", &stats.total_hits)?;
         s.serialize_field("total_score", &stats.total_score)?;
-        s.serialize_field("user", &UserCompactWithoutStats::new(user))?;
+        s.serialize_field("user", &UserWithoutStats::new(user))?;
 
         s.end()
     }
 }
 
-// Serializing a UserCompact reference without statistics
+// Serializing a `User` reference without statistics
 #[cfg(feature = "serialize")]
 #[derive(serde::Serialize)]
-struct UserCompactWithoutStats<'u> {
+struct UserWithoutStats<'u> {
     pub avatar_url: &'u String,
     pub country_code: &'u CountryCode,
     pub default_group: &'u String,
@@ -388,8 +388,8 @@ struct UserCompactWithoutStats<'u> {
 }
 
 #[cfg(feature = "serialize")]
-impl<'u> UserCompactWithoutStats<'u> {
-    fn new(user: &'u User) -> Self {
+impl<'u> UserWithoutStats<'u> {
+    const fn new(user: &'u User) -> Self {
         let User {
             avatar_url,
             country_code,
@@ -435,6 +435,7 @@ impl<'u> UserCompactWithoutStats<'u> {
             scores_first_count,
             scores_recent_count,
             statistics: _,
+            statistics_modes: _,
             support_level,
             pending_mapset_count,
         } = user;

--- a/rosu-v2/src/model/user_.rs
+++ b/rosu-v2/src/model/user_.rs
@@ -643,6 +643,12 @@ pub struct User {
     pub scores_recent_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub statistics: Option<UserStatistics>,
+    #[serde(
+        default,
+        alias = "statistics_rulesets",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub statistics_modes: Option<UserStatisticsModes>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub support_level: Option<u8>,
     #[serde(
@@ -700,10 +706,16 @@ impl From<UserExtended> for User {
             scores_first_count: user.scores_first_count,
             scores_recent_count: user.scores_recent_count,
             statistics: user.statistics,
+            statistics_modes: None,
             support_level: user.support_level,
             pending_mapset_count: user.pending_mapset_count,
         }
     }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Users {
+    pub(crate) users: Vec<User>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -840,6 +852,17 @@ fn maybe_u32<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
 #[inline]
 fn rank_history_vec<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u32>>, D::Error> {
     d.deserialize_option(RankHistoryVisitor)
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+pub struct UserStatisticsModes {
+    pub osu: UserStatistics,
+    pub taiko: UserStatistics,
+    #[serde(alias = "fruits")]
+    pub catch: UserStatistics,
+    pub mania: UserStatistics,
 }
 
 struct RankHistoryVisitor;

--- a/rosu-v2/src/request/user.rs
+++ b/rosu-v2/src/request/user.rs
@@ -15,13 +15,11 @@ use crate::{
     Osu,
 };
 
+use futures::future::TryFutureExt;
 use itoa::Buffer;
 use serde::Serialize;
 use smallstr::SmallString;
 use std::fmt;
-
-#[cfg(feature = "cache")]
-use {futures::future::TryFutureExt, std::mem};
 
 /// Either a user id as u32 or a username as String.
 ///
@@ -314,7 +312,7 @@ impl<'a> GetUserBeatmapsets<'a> {
 
         #[cfg(feature = "cache")]
         {
-            let user_id = mem::replace(&mut self.user_id, UserId::Id(0));
+            let user_id = std::mem::replace(&mut self.user_id, UserId::Id(0));
 
             let fut = osu
                 .cache_user(user_id)
@@ -407,7 +405,7 @@ impl<'a> GetUserKudosu<'a> {
 
         #[cfg(feature = "cache")]
         {
-            let user_id = mem::replace(&mut self.user_id, UserId::Id(0));
+            let user_id = std::mem::replace(&mut self.user_id, UserId::Id(0));
 
             let fut = osu
                 .cache_user(user_id)
@@ -502,7 +500,7 @@ impl<'a> GetUserMostPlayed<'a> {
 
         #[cfg(feature = "cache")]
         {
-            let user_id = mem::replace(&mut self.user_id, UserId::Id(0));
+            let user_id = std::mem::replace(&mut self.user_id, UserId::Id(0));
 
             let fut = osu
                 .cache_user(user_id)
@@ -599,7 +597,7 @@ impl<'a> GetRecentEvents<'a> {
 
         #[cfg(feature = "cache")]
         {
-            let user_id = mem::replace(&mut self.user_id, UserId::Id(0));
+            let user_id = std::mem::replace(&mut self.user_id, UserId::Id(0));
 
             let fut = osu
                 .cache_user(user_id)
@@ -802,7 +800,7 @@ impl<'a> GetUserScores<'a> {
         {
             let score_type = self.score_type;
             let legacy_scores = self.legacy_scores;
-            let user_id = mem::replace(&mut self.user_id, UserId::Id(0));
+            let user_id = std::mem::replace(&mut self.user_id, UserId::Id(0));
 
             let fut = osu
                 .cache_user(user_id)
@@ -873,8 +871,8 @@ impl<'a> GetUsers<'a> {
 
         let fut = osu.request::<Users>(req);
 
-        #[cfg(feature = "cache")]
         let fut = fut.map_ok(|users| {
+            #[cfg(feature = "cache")]
             for user in users.users.iter() {
                 osu.update_cache(user.user_id, &user.username);
             }

--- a/rosu-v2/src/request/user.rs
+++ b/rosu-v2/src/request/user.rs
@@ -1,14 +1,12 @@
 use crate::{
-    error::OsuError,
     model::{
         beatmap::{BeatmapsetExtended, MostPlayedMap, RankStatus},
         kudosu_::KudosuHistory,
         recent_event_::RecentEvent,
         score_::Score,
-        user_::{User, UserExtended},
+        user_::{User, UserExtended, Username, Users},
         GameMode,
     },
-    prelude::Username,
     request::{
         serialize::{maybe_bool_as_u8, maybe_mode_as_str, maybe_user_id_type},
         Pending, Query, Request,
@@ -837,23 +835,26 @@ poll_req!(GetUserScores => Vec<Score>);
 pub struct GetUsers<'a> {
     fut: Option<Pending<'a, Vec<User>>>,
     osu: &'a Osu,
-    form: Option<String>,
+    query: Option<String>,
 }
 
 impl<'a> GetUsers<'a> {
     #[inline]
-    pub(crate) fn new(osu: &'a Osu, user_ids: &[u32]) -> Self {
+    pub(crate) fn new<I>(osu: &'a Osu, user_ids: I) -> Self
+    where
+        I: IntoIterator<Item = u32>,
+    {
         let mut query = String::new();
         let mut buf = Buffer::new();
 
-        let mut iter = user_ids.iter().take(50).copied();
+        let mut iter = user_ids.into_iter().take(50);
 
         if let Some(user_id) = iter.next() {
-            query.push_str("id[]=");
+            query.push_str("ids[]=");
             query.push_str(buf.format(user_id));
 
             for user_id in iter {
-                query.push_str("&id[]=");
+                query.push_str("&ids[]=");
                 query.push_str(buf.format(user_id));
             }
         }
@@ -861,18 +862,27 @@ impl<'a> GetUsers<'a> {
         Self {
             fut: None,
             osu,
-            form: Some(query),
+            query: Some(query),
         }
     }
 
     fn start(&mut self) -> Pending<'a, Vec<User>> {
-        Box::pin(async { Err(OsuError::UnavailableEndpoint) })
+        let query = self.query.take().unwrap();
+        let req = Request::with_query(Route::GetUsers, query);
+        let osu = self.osu;
 
-        // let query = self.query.take().unwrap();
-        // let req = Request::from((query, Route::GetUsers));
+        let fut = osu.request::<Users>(req);
 
-        // // TODO: cache users
-        // Box::pin(self.osu.request(req))
+        #[cfg(feature = "cache")]
+        let fut = fut.map_ok(|users| {
+            for user in users.users.iter() {
+                osu.update_cache(user.user_id, &user.username);
+            }
+
+            users.users
+        });
+
+        Box::pin(fut)
     }
 }
 

--- a/rosu-v2/src/routing.rs
+++ b/rosu-v2/src/routing.rs
@@ -192,7 +192,7 @@ impl Route {
     }
 
     #[cfg(feature = "metrics")]
-    pub(crate) fn name(&self) -> &'static str {
+    pub(crate) const fn name(&self) -> &'static str {
         match self {
             Self::GetBeatmap => "GetBeatmap",
             Self::GetBeatmaps => "GetBeatmaps",

--- a/rosu-v2/tests/requests.rs
+++ b/rosu-v2/tests/requests.rs
@@ -517,10 +517,8 @@ async fn user_scores_legacy() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "currently unavailable"]
 async fn users() -> Result<()> {
-    #[allow(deprecated)]
-    let users = OSU.get().await?.users(&[BADEWANNE3, SYLAS]).await?;
+    let users = OSU.get().await?.users([BADEWANNE3, SYLAS]).await?;
     println!("Received {} users", users.len());
 
     Ok(())

--- a/rosu-v2/tests/serde.rs
+++ b/rosu-v2/tests/serde.rs
@@ -815,6 +815,12 @@ mod types {
             scores_first_count: Some(34),
             scores_recent_count: Some(34),
             statistics: Some(get_user_stats()),
+            statistics_modes: Some(UserStatisticsModes {
+                osu: get_user_stats(),
+                taiko: get_user_stats(),
+                catch: get_user_stats(),
+                mania: get_user_stats(),
+            }),
             support_level: Some(1),
             pending_mapset_count: Some(34),
         }


### PR DESCRIPTION
Removed the deprecation warning on `Osu::users` and it no longer always returns an error. Instead, it now provides `User` (not extended) data for up to 50 users, including statistics for all modes.

This PR includes breaking changes:
- The `User` struct has a new field `statistics_modes: UserStatisticsModes`
- The `Osu::users` method no longer takes a `&[u32]` but a `impl IntoIterator<Item = u32>`