### PR TITLE
feat!: include count_* in user stats

### DIFF
--- a/rosu-v2/src/model/user_.rs
+++ b/rosu-v2/src/model/user_.rs
@@ -805,6 +805,14 @@ pub struct UserStatistics {
     /// Hit accuracy percentage
     #[serde(rename = "hit_accuracy")]
     pub accuracy: f32,
+    /// Total number of n300s
+    pub count_300: u32,
+    /// Total number of n100s
+    pub count_100: u32,
+    /// Total number of n50s
+    pub count_50: u32,
+    /// Total number of misses
+    pub count_miss: u32,
     /// Current country rank according to pp
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub country_rank: Option<u32>,

--- a/rosu-v2/tests/serde.rs
+++ b/rosu-v2/tests/serde.rs
@@ -836,6 +836,10 @@ mod types {
     pub(super) fn get_user_stats() -> UserStatistics {
         UserStatistics {
             accuracy: 99.11,
+            count_300: 12,
+            count_100: 34,
+            count_50: 56,
+            count_miss: 78,
             country_rank: Some(1),
             global_rank: Some(1),
             grade_counts: GradeCounts {


### PR DESCRIPTION
Includes breaking changes, added new fields to `UserStatistics`:
- `count_300`
- `count_100`
- `count_50`
- `count_miss`