### PR TITLE
feat!: added events endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following endpoints are currently supported:
 - `beatmapsets/search`: Search for beatmapsets; the same search as on the osu! website
 - `beatmapsets/lookup`: Find a beatmapset using a beatmap ID.
 - `comments`: Most recent comments and their replies up to two levels deep
+- `events`: Collection of events in order of creation time
 - `forums/topics/{topic_id}`: A forum topic and its posts
 - `matches`: List of currently open multiplayer lobbies
 - `matches/{match_id}`: More specific data about a specific multiplayer lobby including participating players and occured events

--- a/rosu-v2/src/client/mod.rs
+++ b/rosu-v2/src/client/mod.rs
@@ -254,6 +254,12 @@ impl Osu {
         GetCountryRankings::new(self, mode)
     }
 
+    /// Get a vec of [`Event`](crate::model::event::Event).
+    #[inline]
+    pub const fn events(&self) -> GetEvents<'_> {
+        GetEvents::new(self)
+    }
+
     /// Get a [`ForumPosts`](crate::model::forum::ForumPosts) struct for a forum topic
     #[inline]
     pub const fn forum_posts(&self, topic_id: u64) -> GetForumPosts<'_> {

--- a/rosu-v2/src/client/mod.rs
+++ b/rosu-v2/src/client/mod.rs
@@ -315,7 +315,7 @@ impl Osu {
     }
 
     /// Get the recent activity of a user in form of a vec of
-    /// [`RecentEvent`](crate::model::recent_event::RecentEvent)s.
+    /// [`Event`](crate::model::event::Event)s.
     #[cfg(not(feature = "cache"))]
     #[inline]
     pub const fn recent_activity(&self, user_id: u32) -> GetRecentActivity<'_> {
@@ -323,7 +323,7 @@ impl Osu {
     }
 
     /// Get the recent activity of a user in form of a vec of
-    /// [`RecentEvent`](crate::model::recent_event::RecentEvent)s.
+    /// [`Event`](crate::model::event::Event)s.
     #[cfg(feature = "cache")]
     #[inline]
     pub fn recent_activity(&self, user_id: impl Into<UserId>) -> GetRecentActivity<'_> {

--- a/rosu-v2/src/client/mod.rs
+++ b/rosu-v2/src/client/mod.rs
@@ -318,16 +318,16 @@ impl Osu {
     /// [`RecentEvent`](crate::model::recent_event::RecentEvent)s.
     #[cfg(not(feature = "cache"))]
     #[inline]
-    pub const fn recent_events(&self, user_id: u32) -> GetRecentEvents<'_> {
-        GetRecentEvents::new(self, user_id)
+    pub const fn recent_activity(&self, user_id: u32) -> GetRecentActivity<'_> {
+        GetRecentActivity::new(self, user_id)
     }
 
     /// Get the recent activity of a user in form of a vec of
     /// [`RecentEvent`](crate::model::recent_event::RecentEvent)s.
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn recent_events(&self, user_id: impl Into<UserId>) -> GetRecentEvents<'_> {
-        GetRecentEvents::new(self, user_id.into())
+    pub fn recent_activity(&self, user_id: impl Into<UserId>) -> GetRecentActivity<'_> {
+        GetRecentActivity::new(self, user_id.into())
     }
 
     /// Get the replay of a score in form of a [`Replay`](osu_db::Replay).

--- a/rosu-v2/src/lib.rs
+++ b/rosu-v2/src/lib.rs
@@ -149,8 +149,8 @@ pub mod prelude {
         client::Scope,
         error::OsuError,
         model::{
-            beatmap::*, comments::*, forum::*, kudosu::*, matches::*, mods::*, news::*, ranking::*,
-            recent_event::*, score::*, seasonal_backgrounds::*, user::*, wiki::*, Cursor, GameMode,
+            beatmap::*, comments::*, event::*, forum::*, kudosu::*, matches::*, mods::*, news::*,
+            ranking::*, score::*, seasonal_backgrounds::*, user::*, wiki::*, Cursor, GameMode,
             Grade,
         },
         mods,

--- a/rosu-v2/src/lib.rs
+++ b/rosu-v2/src/lib.rs
@@ -32,6 +32,7 @@
 //! - `beatmapsets/events`: Various events around a beatmapset such as status, genre, or language updates, kudosu transfers, or new issues
 //! - `beatmapsets/search`: Search for beatmapsets; the same search as on the osu! website
 //! - `comments`: Most recent comments and their replies up to two levels deep
+//! - `events`: Collection of events in order of creation time
 //! - `forums/topics/{topic_id}`: A forum topic and its posts
 //! - `matches`: List of currently open multiplayer lobbies
 //! - `matches/{match_id}`: More specific data about a specific multiplayer lobby including participating players and occured events

--- a/rosu-v2/src/model/event_.rs
+++ b/rosu-v2/src/model/event_.rs
@@ -15,7 +15,7 @@ use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
-pub struct RecentEvent {
+pub struct Event {
     #[serde(with = "serde_::datetime")]
     #[cfg_attr(feature = "rkyv", with(super::rkyv_impls::DateTimeWrapper))]
     pub created_at: OffsetDateTime,

--- a/rosu-v2/src/model/event_.rs
+++ b/rosu-v2/src/model/event_.rs
@@ -1,15 +1,53 @@
-use serde::Deserialize;
+use std::fmt;
+
+use serde::{de, Deserialize};
 use time::OffsetDateTime;
+
+use crate::{Osu, OsuResult};
 
 use super::{
     beatmap::RankStatus,
     serde_,
-    user_::{Medal, Username},
+    user::{Medal, Username},
     GameMode, Grade,
 };
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
+
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+pub struct Events {
+    pub events: Vec<Event>,
+    #[serde(rename = "cursor_string", skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) sort: Option<EventSort>,
+}
+
+impl Events {
+    /// Returns whether there is a next page of events, retrievable via
+    /// [`get_next`](Events::get_next).
+    #[inline]
+    pub const fn has_more(&self) -> bool {
+        self.cursor.is_some()
+    }
+
+    /// If [`has_more`](Events::has_more) is true, the API can provide the next
+    /// set of events and this method will request them. Otherwise, this method
+    /// returns `None`.
+    pub async fn get_next(&self, osu: &Osu) -> Option<OsuResult<Events>> {
+        let cursor = self.cursor.as_deref()?;
+
+        let fut = osu
+            .events()
+            .cursor(cursor)
+            .sort(self.sort.unwrap_or_default());
+
+        Some(fut.await)
+    }
+}
 
 /// The object has different attributes depending on its type.
 #[derive(Clone, Debug, Deserialize)]
@@ -114,6 +152,53 @@ pub enum EventType {
         /// Includes previous_username
         user: EventUser,
     },
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "rkyv", derive(Archive, RkyvDeserialize, RkyvSerialize))]
+pub enum EventSort {
+    #[default]
+    IdDescending,
+    IdAscending,
+}
+
+impl EventSort {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::IdDescending => "id_desc",
+            Self::IdAscending => "id_asc",
+        }
+    }
+}
+
+impl<'de> de::Deserialize<'de> for EventSort {
+    fn deserialize<D: de::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct EventSortVisitor;
+
+        impl<'de> de::Visitor<'de> for EventSortVisitor {
+            type Value = EventSort;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("id_desc or id_asc")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "id_desc" => Ok(EventSort::IdDescending),
+                    "id_asc" => Ok(EventSort::IdAscending),
+                    _ => Err(de::Error::invalid_value(de::Unexpected::Str(v), &self)),
+                }
+            }
+        }
+
+        d.deserialize_str(EventSortVisitor)
+    }
+}
+
+impl serde::Serialize for EventSort {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/rosu-v2/src/model/mod.rs
+++ b/rosu-v2/src/model/mod.rs
@@ -168,12 +168,12 @@ mod rkyv_impls;
 
 pub(crate) mod beatmap_;
 pub(crate) mod comments_;
+pub(crate) mod event_;
 pub(crate) mod forum_;
 pub(crate) mod kudosu_;
 pub(crate) mod matches_;
 pub(crate) mod news_;
 pub(crate) mod ranking_;
-pub(crate) mod recent_event_;
 pub(crate) mod score_;
 pub(crate) mod seasonal_backgrounds_;
 pub(crate) mod user_;
@@ -231,10 +231,8 @@ pub mod ranking {
 }
 
 /// User event related types
-pub mod recent_event {
-    pub use super::recent_event_::{
-        EventBeatmap, EventBeatmapset, EventType, EventUser, RecentEvent,
-    };
+pub mod event {
+    pub use super::event_::{Event, EventBeatmap, EventBeatmapset, EventType, EventUser};
 }
 
 /// Score related types
@@ -291,6 +289,12 @@ pub mod rkyv {
         CommentableMetaResolver,
     };
 
+    pub use super::event_::{
+        ArchivedEvent, ArchivedEventBeatmap, ArchivedEventBeatmapset, ArchivedEventType,
+        ArchivedEventUser, EventBeatmapResolver, EventBeatmapsetResolver, EventResolver,
+        EventTypeResolver, EventUserResolver,
+    };
+
     pub use super::forum_::{
         ArchivedForumPost, ArchivedForumPostsSearch, ArchivedForumTopic, ForumPostResolver,
         ForumPostsSearchResolver, ForumTopicResolver,
@@ -313,12 +317,6 @@ pub mod rkyv {
         ArchivedChartRankings, ArchivedCountryRanking, ArchivedCountryRankings, ArchivedRankings,
         ArchivedSpotlight, ChartRankingsResolver, CountryRankingResolver, CountryRankingsResolver,
         RankingsResolver, SpotlightResolver,
-    };
-
-    pub use super::recent_event_::{
-        ArchivedEventBeatmap, ArchivedEventBeatmapset, ArchivedEventType, ArchivedEventUser,
-        ArchivedRecentEvent, EventBeatmapResolver, EventBeatmapsetResolver, EventTypeResolver,
-        EventUserResolver, RecentEventResolver,
     };
 
     pub use super::score_::{

--- a/rosu-v2/src/model/mod.rs
+++ b/rosu-v2/src/model/mod.rs
@@ -232,7 +232,9 @@ pub mod ranking {
 
 /// User event related types
 pub mod event {
-    pub use super::event_::{Event, EventBeatmap, EventBeatmapset, EventType, EventUser};
+    pub use super::event_::{
+        Event, EventBeatmap, EventBeatmapset, EventSort, EventType, EventUser, Events,
+    };
 }
 
 /// Score related types
@@ -290,9 +292,10 @@ pub mod rkyv {
     };
 
     pub use super::event_::{
-        ArchivedEvent, ArchivedEventBeatmap, ArchivedEventBeatmapset, ArchivedEventType,
-        ArchivedEventUser, EventBeatmapResolver, EventBeatmapsetResolver, EventResolver,
-        EventTypeResolver, EventUserResolver,
+        ArchivedEvent, ArchivedEventBeatmap, ArchivedEventBeatmapset, ArchivedEventSort,
+        ArchivedEventType, ArchivedEventUser, ArchivedEvents, EventBeatmapResolver,
+        EventBeatmapsetResolver, EventResolver, EventSortResolver, EventTypeResolver,
+        EventUserResolver, EventsResolver,
     };
 
     pub use super::forum_::{

--- a/rosu-v2/src/request/event.rs
+++ b/rosu-v2/src/request/event.rs
@@ -1,0 +1,67 @@
+use futures::TryFutureExt;
+use serde::Serialize;
+
+use crate::{
+    model::event::{EventSort, Events},
+    routing::Route,
+    Osu,
+};
+
+use super::{Pending, Query, Request};
+
+/// Get a vec of [`Event`](crate::model::event::Event).
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Serialize)]
+pub struct GetEvents<'a> {
+    #[serde(skip)]
+    fut: Option<Pending<'a, Events>>,
+    #[serde(skip)]
+    osu: &'a Osu,
+    sort: Option<EventSort>,
+    #[serde(rename = "cursor_string")]
+    cursor: Option<&'a str>,
+}
+
+impl<'a> GetEvents<'a> {
+    #[inline]
+    pub(crate) const fn new(osu: &'a Osu) -> Self {
+        Self {
+            fut: None,
+            osu,
+            sort: None,
+            cursor: None,
+        }
+    }
+
+    /// Sorting option
+    #[inline]
+    pub const fn sort(mut self, sort: EventSort) -> Self {
+        self.sort = Some(sort);
+
+        self
+    }
+
+    /// Cursor for pagination
+    #[inline]
+    pub const fn cursor(mut self, cursor: &'a str) -> Self {
+        self.cursor = Some(cursor);
+
+        self
+    }
+
+    fn start(&mut self) -> Pending<'a, Events> {
+        let sort = self.sort;
+        let query = Query::encode(self);
+        let req = Request::with_query(Route::GetEvents, query);
+
+        let fut = self.osu.request::<Events>(req).map_ok(move |mut events| {
+            events.sort = sort;
+
+            events
+        });
+
+        Box::pin(fut)
+    }
+}
+
+poll_req!(GetEvents => Events);

--- a/rosu-v2/src/request/mod.rs
+++ b/rosu-v2/src/request/mod.rs
@@ -22,6 +22,7 @@ macro_rules! poll_req {
 
 mod beatmap;
 mod comments;
+mod event;
 mod forum;
 mod matches;
 mod news;
@@ -34,6 +35,7 @@ mod wiki;
 
 pub use beatmap::*;
 pub use comments::*;
+pub use event::*;
 pub use forum::*;
 pub use matches::*;
 pub use news::*;

--- a/rosu-v2/src/request/user.rs
+++ b/rosu-v2/src/request/user.rs
@@ -524,7 +524,7 @@ poll_req!(GetUserMostPlayed => Vec<MostPlayedMap>);
 /// Get a vec of [`RecentEvent`](crate::model::recent_event::RecentEvent) of a user by their id.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Serialize)]
-pub struct GetRecentEvents<'a> {
+pub struct GetRecentActivity<'a> {
     #[serde(skip)]
     fut: Option<Pending<'a, Vec<RecentEvent>>>,
     #[serde(skip)]
@@ -541,7 +541,7 @@ pub struct GetRecentEvents<'a> {
     user_id: UserId,
 }
 
-impl<'a> GetRecentEvents<'a> {
+impl<'a> GetRecentActivity<'a> {
     #[cfg(not(feature = "cache"))]
     #[inline]
     pub(crate) const fn new(osu: &'a Osu, user_id: u32) -> Self {
@@ -590,7 +590,7 @@ impl<'a> GetRecentEvents<'a> {
         #[cfg(not(feature = "cache"))]
         {
             let user_id = self.user_id;
-            let req = Request::with_query(Route::GetRecentEvents { user_id }, query);
+            let req = Request::with_query(Route::GetRecentActivity { user_id }, query);
 
             Box::pin(osu.request(req))
         }
@@ -602,7 +602,7 @@ impl<'a> GetRecentEvents<'a> {
             let fut = osu
                 .cache_user(user_id)
                 .map_ok(move |user_id| {
-                    Request::with_query(Route::GetRecentEvents { user_id }, query)
+                    Request::with_query(Route::GetRecentActivity { user_id }, query)
                 })
                 .and_then(move |req| osu.request(req));
 
@@ -611,7 +611,7 @@ impl<'a> GetRecentEvents<'a> {
     }
 }
 
-poll_req!(GetRecentEvents => Vec<RecentEvent>);
+poll_req!(GetRecentActivity => Vec<RecentEvent>);
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum ScoreType {

--- a/rosu-v2/src/request/user.rs
+++ b/rosu-v2/src/request/user.rs
@@ -1,10 +1,11 @@
 use crate::{
     model::{
         beatmap::{BeatmapsetExtended, MostPlayedMap, RankStatus},
-        kudosu_::KudosuHistory,
-        recent_event_::RecentEvent,
-        score_::Score,
-        user_::{User, UserExtended, Username, Users},
+        event::Event,
+        kudosu::KudosuHistory,
+        score::Score,
+        user::{User, UserExtended, Username},
+        user_::Users,
         GameMode,
     },
     request::{
@@ -521,12 +522,12 @@ impl<'a> GetUserMostPlayed<'a> {
 
 poll_req!(GetUserMostPlayed => Vec<MostPlayedMap>);
 
-/// Get a vec of [`RecentEvent`](crate::model::recent_event::RecentEvent) of a user by their id.
+/// Get a vec of [`Event`](crate::model::event::Event) of a user by their id.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Serialize)]
 pub struct GetRecentActivity<'a> {
     #[serde(skip)]
-    fut: Option<Pending<'a, Vec<RecentEvent>>>,
+    fut: Option<Pending<'a, Vec<Event>>>,
     #[serde(skip)]
     osu: &'a Osu,
     limit: Option<usize>,
@@ -583,7 +584,7 @@ impl<'a> GetRecentActivity<'a> {
         self
     }
 
-    fn start(&mut self) -> Pending<'a, Vec<RecentEvent>> {
+    fn start(&mut self) -> Pending<'a, Vec<Event>> {
         let query = Query::encode(self);
         let osu = self.osu;
 
@@ -611,7 +612,7 @@ impl<'a> GetRecentActivity<'a> {
     }
 }
 
-poll_req!(GetRecentActivity => Vec<RecentEvent>);
+poll_req!(GetRecentActivity => Vec<Event>);
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum ScoreType {

--- a/rosu-v2/src/routing.rs
+++ b/rosu-v2/src/routing.rs
@@ -48,7 +48,7 @@ pub(crate) enum Route {
         mode: GameMode,
         ranking_type: RankingType,
     },
-    GetRecentEvents {
+    GetRecentActivity {
         user_id: u32,
     },
     GetReplay {
@@ -142,7 +142,7 @@ impl Route {
                 Method::GET,
                 format!("rankings/{mode}/{}", ranking_type.as_str()).into(),
             ),
-            Self::GetRecentEvents { user_id } => (
+            Self::GetRecentActivity { user_id } => (
                 Method::GET,
                 format!("users/{user_id}/recent_activity").into(),
             ),
@@ -218,7 +218,7 @@ impl Route {
                 RankingType::Performance => "GetRankings/Performance",
                 RankingType::Score => "GetRankings/Score",
             },
-            Self::GetRecentEvents { .. } => "GetRecentEvents",
+            Self::GetRecentActivity { .. } => "GetRecentActivity",
             Self::GetReplay { .. } => "GetReplay",
             Self::GetScore { .. } => "GetScore",
             Self::GetSeasonalBackgrounds => "GetSeasonalBackgrounds",

--- a/rosu-v2/src/routing.rs
+++ b/rosu-v2/src/routing.rs
@@ -207,7 +207,7 @@ impl Route {
             Self::GetBeatmapsetEvents => "GetBeatmapsetEvents",
             Self::GetBeatmapsetSearch => "GetBeatmapsetSearch",
             Self::GetComments => "GetComments",
-            Self::Events => "GetEvents",
+            Self::GetEvents => "GetEvents",
             Self::GetForumPosts { .. } => "GetForumPosts",
             Self::GetMatch { match_id } => match match_id {
                 Some(_) => "GetMatch/match_id",

--- a/rosu-v2/src/routing.rs
+++ b/rosu-v2/src/routing.rs
@@ -32,6 +32,7 @@ pub(crate) enum Route {
     GetBeatmapsetEvents,
     GetBeatmapsetSearch,
     GetComments,
+    GetEvents,
     GetForumPosts {
         topic_id: u64,
     },
@@ -111,6 +112,7 @@ impl Route {
             Self::GetBeatmapsetEvents => (Method::GET, "beatmapsets/events".into()),
             Self::GetBeatmapsetSearch => (Method::GET, "beatmapsets/search".into()),
             Self::GetComments => (Method::GET, "comments".into()),
+            Self::GetEvents => (Method::GET, "events".into()),
             Self::GetForumPosts { topic_id } => {
                 (Method::GET, format!("forums/topics/{topic_id}").into())
             }
@@ -205,6 +207,7 @@ impl Route {
             Self::GetBeatmapsetEvents => "GetBeatmapsetEvents",
             Self::GetBeatmapsetSearch => "GetBeatmapsetSearch",
             Self::GetComments => "GetComments",
+            Self::Events => "GetEvents",
             Self::GetForumPosts { .. } => "GetForumPosts",
             Self::GetMatch { match_id } => match match_id {
                 Some(_) => "GetMatch/match_id",

--- a/rosu-v2/tests/requests.rs
+++ b/rosu-v2/tests/requests.rs
@@ -286,7 +286,7 @@ async fn recent_events() -> Result<()> {
     let events = OSU
         .get()
         .await?
-        .recent_events("badewanne3")
+        .recent_activity("badewanne3")
         .limit(10)
         .offset(2)
         .await?;

--- a/rosu-v2/tests/requests.rs
+++ b/rosu-v2/tests/requests.rs
@@ -282,7 +282,7 @@ async fn forum_posts() -> Result<()> {
 
 #[cfg(feature = "cache")]
 #[tokio::test]
-async fn recent_events() -> Result<()> {
+async fn recent_activity() -> Result<()> {
     let events = OSU
         .get()
         .await?


### PR DESCRIPTION
Adds the `/events` endpoint.

Breaking changes:
- Renamed the struct `GetRecentEvents` to `GetRecentActivity`
- Renamed the struct `RecentEvent` to `Event`
- Renamed the method `Osu::recent_events` to `Osu::recent_activity`