### PR TITLE
feat!: added unknown mod

### DIFF
--- a/generate-mods/src/model.rs
+++ b/generate-mods/src/model.rs
@@ -82,7 +82,7 @@ impl RulesetMods {
 pub struct Acronym([u8; 3]);
 
 impl Acronym {
-    fn from_str(s: &str) -> Option<Self> {
+    pub fn from_str(s: &str) -> Option<Self> {
         match <[u8; 2]>::try_from(s.as_bytes()) {
             Ok([a, b]) => Some(Self([0, a, b])),
             Err(_) => s.as_bytes().try_into().map(Self).ok(),

--- a/rosu-v2/src/error.rs
+++ b/rosu-v2/src/error.rs
@@ -125,9 +125,6 @@ pub enum ParsingError {
     /// Failed to parse a str into an [`Acronym`](crate::model::mods::Acronym)
     #[error("failed to parse `{}` into an Acronym", .0)]
     Acronym(Box<str>),
-    /// Failed to parse a str into [`GameModsIntermode`](crate::model::mods::GameModsIntermode)
-    #[error("failed to parse `{}` into GameModsIntermode", .0)]
-    GameModsIntermode(Box<str>),
     /// Failed to parse a u8 into a [`Genre`](crate::model::beatmap::Genre)
     #[error("failed to parse {} into Genre", .0)]
     Genre(u8),

--- a/rosu-v2/src/model/mods/acronym.rs
+++ b/rosu-v2/src/model/mods/acronym.rs
@@ -1,11 +1,20 @@
 use std::{
+    cmp::Ordering,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
     str::FromStr,
 };
 
 use crate::error::ParsingError;
 
+/// The acronym of a [`GameMod`].
+///
+/// [`GameMod`]: crate::model::mods::GameMod
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize),
+    archive(as = "Self")
+)]
 pub struct Acronym([u8; 3]);
 
 impl Acronym {
@@ -91,5 +100,17 @@ impl FromStr for Acronym {
                 })
                 .map_err(|_| ParsingError::Acronym(Box::from(s))),
         }
+    }
+}
+
+impl PartialOrd for Acronym {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Acronym {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
     }
 }

--- a/rosu-v2/src/model/mods/mode_as_seed.rs
+++ b/rosu-v2/src/model/mods/mode_as_seed.rs
@@ -48,18 +48,15 @@ impl<'de> Visitor<'de> for ModeAsSeed<GameMods> {
     }
 
     fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
-        v.parse::<GameModsIntermode>()
-            .map_err(DeError::custom)?
-            .with_mode(self.mode)
-            .ok_or_else(|| DeError::custom(format!("invalid mods for mode {:?}", self.mode)))
+        let mods = v.parse::<GameModsIntermode>().map_err(DeError::custom)?;
+
+        Ok(mods.with_mode(self.mode))
     }
 
     fn visit_u64<E: DeError>(self, v: u64) -> Result<Self::Value, E> {
         let bits = u32::try_from(v).map_err(|_| DeError::custom("bitflags must fit in a u32"))?;
 
-        GameModsIntermode::from_bits(bits)
-            .with_mode(self.mode)
-            .ok_or_else(|| DeError::custom(format!("invalid mods for mode {:?}", self.mode)))
+        Ok(GameModsIntermode::from_bits(bits).with_mode(self.mode))
     }
 
     fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {


### PR DESCRIPTION
Instead of breaking as soon as an unknown mod is encountered, `GameMod` and `GameModIntermode` now have a dedicated variant to catch the new `UnknownMod` struct which only contains the mod's acronym.

Deserialization now uses the non-fallible way to handle mods, as does the `FromStr` impl.

Conversion between `GameMods` and `GameModsIntermode` now has a checked and an "unknown mod" version.