### PR TITLE
feat: added local oauth

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
           - kind: default-features
             features: default
           - kind: full-features
-            features: cache,macros,metrics,replay,serialize
+            features: cache,macros,metrics,replay,serialize,local_oauth
 
     steps:
       - name: Checkout project
@@ -100,7 +100,7 @@ jobs:
           cargo hack check
           --feature-powerset --no-dev-deps
           --optional-deps metrics
-          --group-features default,cache,macros,deny_unknown_fields
+          --group-features default,cache,macros,local_oauth,deny_unknown_fields
 
   readme:
     name: Readme

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cache = ["dashmap"]
 macros = ["rosu-mods/macros"]
 replay = ["osu-db"]
 serialize = []
+local_oauth = ["tokio/net"]
 deny_unknown_fields = []
 
 # --- Dependencies ---

--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ async fn main() {
 
 ### Features
 
-| Flag        | Description                              | Dependencies
-| ----------- | ---------------------------------------- | ------------
-| `default`   | Enable the `cache` and `macros` features |
-| `cache`     | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
-| `macros`    | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
-| `serialize` | Implement `serde::Serialize` for most types, allowing for manual serialization |
-| `metrics`   | Uses the global metrics registry to store response time for each endpoint | [`metrics`]
-| `replay`    | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [`osu-db`]
+| Flag          | Description                              | Dependencies
+| ------------- | ---------------------------------------- | ------------
+| `default`     | Enable the `cache` and `macros` features |
+| `cache`       | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
+| `macros`      | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
+| `serialize`   | Implement `serde::Serialize` for most types, allowing for manual serialization |
+| `metrics`     | Uses the global metrics registry to store response time for each endpoint | [`metrics`]
+| `replay`      | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [`osu-db`]
+| `local_oauth` | Enables the method `OsuBuilder::with_local_authorization` to perform the full OAuth procedure | `tokio/net` feature
 
 [osu!api v2]: https://osu.ppy.sh/docs/index.html
 [`rosu`]: https://github.com/MaxOhn/rosu

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,24 @@ use serde::Deserialize;
 use serde_json::Error as SerdeError;
 use std::fmt;
 
+#[cfg(feature = "local_oauth")]
+#[cfg_attr(docsrs, doc(cfg(feature = "local_oauth")))]
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    #[error("failed to accept request")]
+    Accept(#[source] tokio::io::Error),
+    #[error("failed to create tcp listener")]
+    Listener(#[source] tokio::io::Error),
+    #[error("missing code in request")]
+    NoCode { data: Vec<u8> },
+    #[error("failed to read data")]
+    Read(#[source] tokio::io::Error),
+    #[error("redirect uri must contain localhost and a port number")]
+    Url,
+    #[error("failed to write data")]
+    Write(#[source] tokio::io::Error),
+}
+
 /// The API response was of the form `{ "error": ... }`
 #[derive(Debug, Deserialize, thiserror::Error)]
 pub struct ApiError {
@@ -60,6 +78,14 @@ pub enum OsuError {
         This should only occur during an extended downtime of the osu!api."
     )]
     NoToken,
+    #[cfg(feature = "local_oauth")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "local_oauth")))]
+    /// Failed to perform OAuth
+    #[error("failed to perform oauth")]
+    OAuth {
+        #[from]
+        source: OAuthError,
+    },
     #[cfg(feature = "replay")]
     #[cfg_attr(docsrs, doc(cfg(feature = "replay")))]
     /// There was an error while trying to use osu-db

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,14 +103,15 @@
 //!
 //! ## Features
 //!
-//! | Flag        | Description                              | Dependencies
-//! | ----------- | ---------------------------------------- | ------------
-//! | `default`   | Enable the `cache` and `macros` features |
-//! | `cache`     | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
-//! | `macros`    | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
-//! | `serialize` | Implement `serde::Serialize` for most types, allowing for manual serialization |
-//! | `metrics`   | Uses the global metrics registry to store response time for each endpoint | [`metrics`]
-//! | `replay`    | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [`osu-db`]
+//! | Flag          | Description                              | Dependencies
+//! | ------------- | ---------------------------------------- | ------------
+//! | `default`     | Enable the `cache` and `macros` features |
+//! | `cache`       | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
+//! | `macros`      | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
+//! | `serialize`   | Implement `serde::Serialize` for most types, allowing for manual serialization |
+//! | `metrics`     | Uses the global metrics registry to store response time for each endpoint | [`metrics`]
+//! | `replay`      | Enables the method `Osu::replay` to parse a replay. Note that `Osu::replay_raw` is available without this feature but provides raw bytes instead of a parsed replay | [`osu-db`]
+//! | `local_oauth` | Enables the method `OsuBuilder::with_local_authorization` to perform the full OAuth procedure | `tokio/net` feature
 //!
 //! [osu!api v2]: https://osu.ppy.sh/docs/index.html
 //! [`rosu`]: https://github.com/MaxOhn/rosu


### PR DESCRIPTION
Adds the method `OsuBuilder::with_local_authorization`. 

Upon building the builder, it prints an authorization url to stdout and awaits a TCP connection on `localhost:[port from redirect uri]`.