### PR TITLE
feat: improve mods deserialization error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,15 @@ pub enum OsuError {
     },
 }
 
+impl OsuError {
+    pub(crate) fn invalid_mods<E: serde::de::Error>(
+        mods: Box<serde_json::value::RawValue>,
+        err: SerdeError,
+    ) -> E {
+        E::custom(format!("invalid mods `{mods}`: {err}"))
+    }
+}
+
 /// Failed some [`TryFrom`] parsing
 #[derive(Debug, thiserror::Error)]
 pub enum ParsingError {


### PR DESCRIPTION
Since mods are first deserialized into a `RawValue` which is then itself used as deserializer, an error will lose information about the line and column.
With this PR it still doesn't specify the right values w.r.t. to entire deserialization body but it prints the `RawValue` which makes it much easier to reason with those adjusted line and column values.