### PR TITLE
feat: add friends endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following endpoints are currently supported:
 - `comments`: Most recent comments and their replies up to two levels deep
 - `events`: Collection of events in order of creation time
 - `forums/topics/{topic_id}`: A forum topic and its posts
+- `friends`: List of authenticated user's friends
 - `matches`: List of currently open multiplayer lobbies
 - `matches/{match_id}`: More specific data about a specific multiplayer lobby including participating players and occured events
 - `me[/{mode}]`: Detailed info about the authenticated user [in the specified mode] (requires OAuth)

--- a/src/client/token.rs
+++ b/src/client/token.rs
@@ -159,9 +159,8 @@ impl AuthorizationBuilder {
                 &response_type=code",
         );
 
-        url.push_str("&scopes=%22");
+        url.push_str("&scope=");
         scopes.format(&mut url, '+');
-        url.push_str("%22");
 
         println!("Authorize yourself through the following url:\n{url}");
         info!("Awaiting manual authorization...");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! - `comments`: Most recent comments and their replies up to two levels deep
 //! - `events`: Collection of events in order of creation time
 //! - `forums/topics/{topic_id}`: A forum topic and its posts
+//! - `friends`: List of authenticated user's friends
 //! - `matches`: List of currently open multiplayer lobbies
 //! - `matches/{match_id}`: More specific data about a specific multiplayer lobby including participating players and occured events
 //! - `me[/{mode}]`: Detailed info about the authenticated user [in the specified mode] (requires OAuth)

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -36,6 +36,7 @@ pub(crate) enum Route {
     GetForumPosts {
         topic_id: u64,
     },
+    GetFriends,
     GetMatch {
         match_id: Option<u32>,
     },
@@ -117,6 +118,7 @@ impl Route {
             Self::GetForumPosts { topic_id } => {
                 (Method::GET, format!("forums/topics/{topic_id}").into())
             }
+            Self::GetFriends => (Method::GET, "friends".into()),
             Self::GetMatch { match_id } => {
                 let path = match match_id {
                     Some(id) => format!("matches/{id}").into(),
@@ -217,6 +219,7 @@ impl Route {
             Self::GetComments => "GetComments",
             Self::GetEvents => "GetEvents",
             Self::GetForumPosts { .. } => "GetForumPosts",
+            Self::GetFriends => "GetFriends",
             Self::GetMatch { match_id } => match match_id {
                 Some(_) => "GetMatch/match_id",
                 None => "GetMatch",


### PR DESCRIPTION
Adds the method `Osu::friends` to retrieve a `Vec<User>` representing the authenticated user's friends. Note that this endpoint only works when authenticated with the `FriendsRead` scope.