### PR TITLE
feat: build client with given token

### DIFF
--- a/src/client/token.rs
+++ b/src/client/token.rs
@@ -228,7 +228,7 @@ impl AuthorizationBuilder {
                     start += KEY.len();
 
                     if let Some(end) = data[start..].find(char::is_whitespace) {
-                        return Some(data[start..][..end].to_owned());
+                        return Some(Box::from(&data[start..][..end]));
                     }
                 }
 
@@ -259,7 +259,7 @@ You may close this tab
 
         Ok(Authorization {
             code,
-            redirect_uri,
+            redirect_uri: redirect_uri.into_boxed_str(),
             scopes,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub type OsuResult<T> = Result<T, error::OsuError>;
 /// All types except requesting, stuffed into one module
 pub mod prelude {
     pub use crate::{
-        client::Scopes,
+        client::{Scopes, Token},
         error::OsuError,
         model::{
             beatmap::*,


### PR DESCRIPTION
Adds the method `OsuBuilder::with_token` to provide a previously acquired `Token`. If the token's refresh value and an expire value is given, the client will also refresh the token automatically.

Closes #39 