### PR TITLE
feat!: add team to `UserExtended`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -176,15 +176,15 @@ pub enum ParsingError {
     /// Failed to parse a u8 into a [`Language`](crate::model::beatmap::Language)
     #[error("failed to parse {} into Language", .0)]
     Language(u8),
+    /// Failed to parse a u8 into a [`MatchTeam`](crate::model::matches::MatchTeam)
+    #[error("failed to parse {} into MatchTeam", .0)]
+    MatchTeam(u8),
     /// Failed to parse an i8 into a [`RankStatus`](crate::model::beatmap::RankStatus)
     #[error("failed to parse {} into RankStatus", .0)]
     RankStatus(i8),
     /// Failed to parse a u8 into a [`ScoringType`](crate::model::matches::ScoringType)
     #[error("failed to parse {} into ScoringType", .0)]
     ScoringType(u8),
-    /// Failed to parse a u8 into a [`Team`](crate::model::matches::Team)
-    #[error("failed to parse {} into Team", .0)]
-    Team(u8),
     /// Failed to parse a u8 into a [`TeamType`](crate::model::matches::TeamType)
     #[error("failed to parse {} into TeamType", .0)]
     TeamType(u8),

--- a/src/model/matches.rs
+++ b/src/model/matches.rs
@@ -533,7 +533,7 @@ pub struct MatchScore {
     pub score: u32,
     pub slot: u8,
     pub statistics: LegacyScoreStatistics,
-    pub team: Team,
+    pub team: MatchTeam,
     pub user_id: u32,
 }
 
@@ -620,7 +620,7 @@ impl<'de> Deserialize<'de> for MatchScore {
 #[derive(Debug, Deserialize)]
 struct MatchScoreInfo {
     slot: u8,
-    team: Team,
+    team: MatchTeam,
     #[serde(deserialize_with = "to_bool")]
     pass: bool,
 }
@@ -993,13 +993,13 @@ impl Default for ScoringType {
     }
 }
 
-def_enum!(Team {
+def_enum!(MatchTeam {
     None = 0 ("none"),
     Blue = 1 ("blue"),
     Red = 2 ("red"),
 });
 
-impl Default for Team {
+impl Default for MatchTeam {
     #[inline]
     fn default() -> Self {
         Self::None

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -279,6 +279,16 @@ pub enum ProfilePage {
     TopRanks,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct Team {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flag_url: Option<String>,
+    pub id: u32,
+    pub name: String,
+    pub short_name: String,
+}
+
 /// Represents a User. Extends [`User`] object with additional attributes.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -357,6 +367,8 @@ pub struct UserExtended {
     pub profile_color: Option<String>,
     /// ordered list of sections in user profile page
     pub profile_order: Vec<ProfilePage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team: Option<Team>,
     /// user-specific title
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -513,7 +513,7 @@ mod types {
                 count_miss: 5,
             },
             slot: 0,
-            team: Team::Red,
+            team: MatchTeam::Red,
             pass: true,
         }
     }
@@ -668,6 +668,12 @@ mod types {
             forum_post_count: 0,
             profile_color: Some(String::new()),
             profile_order: vec![ProfilePage::Me, ProfilePage::TopRanks],
+            team: Some(Team {
+                flag_url: None,
+                id: 1024,
+                name: "Traceable Enjoyer".to_owned(),
+                short_name: "TC".to_owned(),
+            }),
             title: Some(String::new()),
             title_url: Some(String::new()),
             twitter: Some(String::new()),


### PR DESCRIPTION
Breaking:
- Renames enum `rosu_v2::model::matches::Team` to `MatchTeam`
- Renames variant `ParsingError::Team` to `MatchTeam`
- Adds the field `team: Option<Team>` to `UserExtended`