### PR TITLE
fix: Update BeatmapDifficultyAttributes fields to match the upstream API changes

### DIFF
--- a/src/model/beatmap.rs
+++ b/src/model/beatmap.rs
@@ -164,8 +164,8 @@ pub struct BeatmapDifficultyAttributes {
     pub max_combo: u32,
     #[serde(rename = "star_rating")]
     pub stars: f64,
-    #[serde(flatten)]
-    pub attrs: GameModeAttributes,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub attrs: Option<GameModeAttributes>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -173,29 +173,23 @@ pub struct BeatmapDifficultyAttributes {
 #[serde(untagged)]
 pub enum GameModeAttributes {
     Osu {
-        #[serde(rename = "approach_rate")]
-        ar: f32,
-        #[serde(rename = "overall_difficulty")]
-        od: f32,
         aim_difficulty: f64,
-        flashlight_difficulty: f64,
         slider_factor: f64,
         speed_difficulty: f64,
         speed_note_count: f64,
+        aim_difficult_slider_count: f64,
+        aim_difficult_strain_count: f64,
+        speed_difficult_strain_count: f64,
     },
     Taiko {
         stamina_difficulty: f64,
         rhythm_difficulty: f64,
+        reading_difficulty: f64,
         colour_difficulty: f64,
-        peak_difficulty: f64,
-        great_hit_window: f32,
-    },
-    Catch {
-        #[serde(rename = "approach_rate")]
-        ar: f32,
-    },
-    Mania {
-        great_hit_window: f32,
+        mono_stamina_factor: f64,
+        stamina_difficult_strains: f64,
+        rhythm_difficult_strains: f64,
+        colour_difficult_strains: f64,
     },
 }
 

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -98,14 +98,20 @@ async fn beatmap() -> Result<()> {
 
 #[tokio::test]
 async fn beatmap_difficulty_attributes() -> Result<()> {
-    let attrs = OSU
-        .get()
-        .await?
-        .beatmap_difficulty_attributes(ADESSO_BALLA)
-        .mode(GameMode::Taiko)
-        .await?;
+    let attrs = OSU.get().await?;
 
-    println!("{:?}", attrs.attrs);
+    for mode in [
+        GameMode::Osu,
+        GameMode::Taiko,
+        GameMode::Catch,
+        GameMode::Mania,
+    ] {
+        let attrs = attrs
+            .beatmap_difficulty_attributes(ADESSO_BALLA)
+            .mode(mode)
+            .await?;
+        println!("{:?}", attrs.attrs);
+    }
 
     Ok(())
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -912,33 +912,34 @@ mod types {
             BeatmapDifficultyAttributes {
                 max_combo: 1,
                 stars: 2.0,
-                attrs: GameModeAttributes::Osu {
-                    ar: 5.55,
-                    od: 6.66,
+                attrs: Some(GameModeAttributes::Osu {
                     aim_difficulty: 4.44,
-                    flashlight_difficulty: 3.33,
                     slider_factor: 2.22,
                     speed_difficulty: 1.11,
                     speed_note_count: 77.7777,
-                },
+                    aim_difficult_slider_count: 88.8888,
+                    aim_difficult_strain_count: 99.9999,
+                    speed_difficult_strain_count: 66.6666,
+                }),
             },
             BeatmapDifficultyAttributes {
                 max_combo: 3,
                 stars: 4.0,
-                attrs: GameModeAttributes::Taiko {
+                attrs: Some(GameModeAttributes::Taiko {
                     stamina_difficulty: 7.89,
                     rhythm_difficulty: 4.56,
                     colour_difficulty: 1.23,
-                    peak_difficulty: 999.99,
-                    great_hit_window: 10.0,
-                },
+                    reading_difficulty: 3.21,
+                    mono_stamina_factor: 0.0123,
+                    rhythm_difficult_strains: 0.0456,
+                    colour_difficult_strains: 0.0789,
+                    stamina_difficult_strains: 0.0321,
+                }),
             },
             BeatmapDifficultyAttributes {
                 max_combo: 5,
                 stars: 6.0,
-                attrs: GameModeAttributes::Mania {
-                    great_hit_window: 1.0,
-                },
+                attrs: None,
             },
         ]
     }


### PR DESCRIPTION
I found it kept failing on deserializing the json fetched and noticed these changes a few days ago. It's not documented yet so I'm not sure if there will be further changes.