### PR TITLE
refactor: use rfc3339 to (de)serialize datetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std", "ra
 serde_urlencoded = { version = "0.7.1" }
 smallstr = { version = "0.3.0", features = ["serde"] }
 thiserror = { version = "2.0.11" }
-time = { version = "0.3", features = ["formatting", "parsing"] }
+time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.0", default-features = false, features = ["macros"] }
 tracing = { version = "0.1.40", default-features = false }
 url = { version = "2.0", default-features = false }


### PR DESCRIPTION
Replaces custom datetime (de)serialization with `time`'s [`rfc3339`](<https://docs.rs/time/latest/time/serde/rfc3339/index.html>).