### PR TITLE
feat!: adjust user mapsets endpoint

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,12 @@ use token::{Authorization, AuthorizationKind, TokenResponse};
 pub use self::{builder::OsuBuilder, scopes::Scopes, token::Token};
 
 #[allow(clippy::wildcard_imports)]
-use crate::{error::OsuError, model::GameMode, request::*, OsuResult};
+use crate::{
+    error::OsuError,
+    model::{user::UserBeatmapsetsKind, GameMode},
+    request::*,
+    OsuResult,
+};
 
 use hyper::{
     body::Incoming,
@@ -424,22 +429,17 @@ impl Osu {
 
     /// Get the [`BeatmapsetExtended`](crate::model::beatmap::BeatmapsetExtended)s of a user by their id.
     ///
-    /// If no map type specified, either manually through
-    /// [`map_type`](crate::request::GetUserBeatmapsets::map_type),
-    /// or through any of the methods [`loved`](crate::request::GetUserBeatmapsets::loved),
-    /// [`favourite`](crate::request::GetUserBeatmapsets::favourite),
-    /// [`graveyard`](crate::request::GetUserBeatmapsets::graveyard),
-    /// [`ranked_and_approved`](crate::request::GetUserBeatmapsets::ranked_and_approved),
-    /// [`unranked`](crate::request::GetUserBeatmapsets::unranked),
-    /// it defaults to `ranked_and_approved`.
-    ///
     /// Filled options will be: `artist_unicode`, `legacy_thread_url`, `maps`, `title_unicode`.
     ///
     /// All options of the contained [`BeatmapExtended`](crate::model::beatmap::BeatmapExtended)s will be `None`.
     #[cfg(not(feature = "cache"))]
     #[inline]
-    pub const fn user_beatmapsets(&self, user_id: u32) -> GetUserBeatmapsets<'_> {
-        GetUserBeatmapsets::new(self, user_id)
+    pub const fn user_beatmapsets(
+        &self,
+        user_id: u32,
+        kind: UserBeatmapsetsKind,
+    ) -> GetUserBeatmapsets<'_> {
+        GetUserBeatmapsets::new(self, user_id, kind)
     }
 
     /// Get a vec of [`BeatmapsetExtended`](crate::model::beatmap::BeatmapsetExtended)s a user made.
@@ -449,8 +449,12 @@ impl Osu {
     /// All options of the contained [`BeatmapExtended`](crate::model::beatmap::BeatmapExtended)s will be `None`.
     #[cfg(feature = "cache")]
     #[inline]
-    pub fn user_beatmapsets(&self, user_id: impl Into<UserId>) -> GetUserBeatmapsets<'_> {
-        GetUserBeatmapsets::new(self, user_id.into())
+    pub fn user_beatmapsets(
+        &self,
+        user_id: impl Into<UserId>,
+        kind: UserBeatmapsetsKind,
+    ) -> GetUserBeatmapsets<'_> {
+        GetUserBeatmapsets::new(self, user_id.into(), kind)
     }
 
     /// Get a vec of a user's [`MostPlayedMap`](crate::model::beatmap::MostPlayedMap)s.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -722,6 +722,35 @@ pub(crate) struct Users {
     pub(crate) users: Vec<User>,
 }
 
+/// Specifies the type of mapsets returned by [`Osu::user_beatmapsets`].
+///
+/// [`Osu::user_beatmapsets`]: crate::Osu::user_beatmapsets
+#[derive(Copy, Clone, Debug)]
+pub enum UserBeatmapsetsKind {
+    Favourite,
+    Graveyard,
+    Guest,
+    Loved,
+    Nominated,
+    Pending,
+    /// Both ranked and approved
+    Ranked,
+}
+
+impl UserBeatmapsetsKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Favourite => "favourite",
+            Self::Graveyard => "graveyard",
+            Self::Guest => "guest",
+            Self::Loved => "loved",
+            Self::Nominated => "nominated",
+            Self::Pending => "pending",
+            Self::Ranked => "ranked",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct UserCover {

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -14,6 +14,7 @@ use rosu_v2::{
         event::EventSort,
         GameMode,
     },
+    prelude::UserBeatmapsetsKind,
     Osu,
 };
 use tokio::sync::{Mutex, MutexGuard};
@@ -547,16 +548,22 @@ async fn user() -> Result<()> {
 
 #[tokio::test]
 async fn user_beatmapsets() -> Result<()> {
-    let mapsets = OSU
-        .get()
-        .await?
-        .user_beatmapsets(SYLAS)
-        .limit(5)
-        .ranked()
-        .offset(2)
-        .await?;
+    let kinds = [
+        UserBeatmapsetsKind::Favourite,
+        UserBeatmapsetsKind::Graveyard,
+        UserBeatmapsetsKind::Guest,
+        UserBeatmapsetsKind::Loved,
+        UserBeatmapsetsKind::Nominated,
+        UserBeatmapsetsKind::Pending,
+        UserBeatmapsetsKind::Ranked,
+    ];
 
-    println!("Received {} mapsets of the user", mapsets.len());
+    let osu = OSU.get().await?;
+
+    for kind in kinds {
+        let mapsets = osu.user_beatmapsets(SYLAS, kind).limit(5).offset(2).await?;
+        println!("Received {} {kind:?} mapsets of the user", mapsets.len());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds a new enum `UserBeatmapsetsKind` and method `GetUserBeatmapsets::kind`.

Breaking changes:
- `UserBeatmapsetsKind` is a new mandatory argument to `Osu::user_beatmapsets`.
- Removed `GetUserBeatmapsets` methods `status` (replaced by new method `kind`), `loved`, `ranked`, `pending`, and `graveyard`

Closes #51