### PR TITLE
feat!: use std RwLock for token

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -57,7 +57,7 @@ impl Osu {
 
     /// Return the [`Token`] that is being used when requesting data.
     #[inline]
-    pub async fn token(&self) -> Token {
+    pub fn token(&self) -> Token {
         self.inner.token.get(Token::to_owned)
     }
 


### PR DESCRIPTION
If read/write-guards aren't being held across await-points, std-lib locks should be preferred over tokio ones.

One technical breaking change is that the `Osu::token` method is no longer async.