### PR TITLE
refactor!: rewrite future logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 output.*
 expanded.*
 /tests/custom.rs
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,13 @@ deny_unknown_fields = []
 [dependencies]
 bytes = { version = "1.10.0", default-features = false }
 futures = { version = "0.3", default-features = false }
-leaky-bucket-lite = { version = "0.5" }
+leaky-bucket = { version = "1.1.2" }
 http-body-util = { version = "0.1.2", default-features = false }
 hyper = { version = "1.6.0", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false, features = ["client-legacy", "http1", "http2", "tokio"] }
 hyper-rustls = { version = "0.27.5", default-features = false, features = ["http1", "http2", "native-tokio", "ring"] }
 itoa = { version = "1.0.9" }
+pin-project = { version = "1.1.10" }
 rosu-mods = { version = "0.3.0", features = ["serde"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "raw_value"] }

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ async fn main() {
 | Flag          | Description                              | Dependencies
 | ------------- | ---------------------------------------- | ------------
 | `default`     | Enable the `cache` and `macros` features |
-| `cache`       | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
+| `cache`       | Cache username-userid pairs so that fetching data by username does one instead of two requests | [`dashmap`]
 | `macros`      | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
 | `serialize`   | Implement `serde::Serialize` for most types, allowing for manual serialization |
 | `metrics`     | Uses the global metrics registry to store response time for each endpoint | [`metrics`]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use hyper::{
-    header::InvalidHeaderValue, http::Error as HttpError, Error as HyperError, StatusCode,
+    body::Bytes, header::InvalidHeaderValue, http::Error as HttpError, Error as HyperError,
+    StatusCode,
 };
 use serde::Deserialize;
 use serde_json::Error as SerdeError;
@@ -101,9 +102,9 @@ pub enum OsuError {
         source: osu_db::Error,
     },
     /// Failed to deserialize response
-    #[error("failed to deserialize response: {}", .body)]
+    #[error("failed to deserialize response: {:?}", .bytes)]
     Parsing {
-        body: String,
+        bytes: Bytes,
         #[source]
         source: SerdeError,
     },
@@ -125,14 +126,14 @@ pub enum OsuError {
     /// API returned an error
     #[error("response error, status {}", .status)]
     Response {
-        body: String,
+        bytes: Bytes,
         #[source]
         source: ApiError,
         status: StatusCode,
     },
     /// Temporal (?) downtime of the osu API
-    #[error("osu!api may be temporarily unavailable (received 503): {}", .0)]
-    ServiceUnavailable(String),
+    #[error("osu!api may be temporarily unavailable (received 503)")]
+    ServiceUnavailable { body: hyper::body::Incoming },
     /// The client's authentication is not sufficient for the endpoint
     #[error("the endpoint is not available for the client's authorization level")]
     UnavailableEndpoint,

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -1,0 +1,209 @@
+use std::{
+    future::{Future, IntoFuture},
+    ops::ControlFlow,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use pin_project::pin_project;
+
+use crate::{
+    request::{GetUser, Request, UserId},
+    Osu, OsuResult,
+};
+
+use self::stage::{OsuFutureStage, OsuRequestStageInner};
+
+pub(crate) use self::token::TokenFuture;
+
+pub use self::traits::*;
+
+mod request_generator;
+mod stage;
+mod token;
+mod traits;
+
+type FromUserFn<T> = fn(u32, <T as OsuFutureData>::FromUserData) -> Request;
+
+struct FromUser<T: OsuFutureData> {
+    data: T::FromUserData,
+    f: FromUserFn<T>,
+}
+
+type PostProcessFn<T> = fn(
+    <T as OsuFutureData>::FromBytes,
+    <T as OsuFutureData>::PostProcessData,
+) -> OsuResult<<T as OsuFutureData>::OsuOutput>;
+
+struct PostProcess<T: OsuFutureData> {
+    data: T::PostProcessData,
+    f: PostProcessFn<T>,
+}
+
+/// Awaitable [`Future`] to fetch and process data from an endpoint.
+///
+/// When fetching from user endpoints by name instead of id, the [`OsuFuture`]
+/// might first perform a request to fetch the user itself, and then perform
+/// the actual request by using the fetched user id. If the `cache` feature
+/// is enabled, fetched user data will be stored to potentially prevent
+/// intermediate user requests later on.
+#[pin_project]
+pub struct OsuFuture<T: OsuFutureData> {
+    #[pin]
+    stage: OsuFutureStage,
+    from_user: Option<FromUser<T>>,
+    post_process: Option<PostProcess<T>>,
+}
+
+impl<T: OsuFutureData> OsuFuture<T> {
+    /// Creates a new [`OsuFuture`] from the given [`Request`].
+    pub(crate) fn new(
+        osu: &Osu,
+        req: Request,
+        post_process_data: T::PostProcessData,
+        post_process_fn: PostProcessFn<T>,
+    ) -> Self {
+        let osu = Arc::clone(&osu.inner);
+
+        Self {
+            stage: OsuRequestStageInner::new(osu, req)
+                .map_or_else(OsuFutureStage::Failed, OsuFutureStage::Final),
+            from_user: None,
+            post_process: Some(PostProcess {
+                data: post_process_data,
+                f: post_process_fn,
+            }),
+        }
+    }
+
+    /// Creates a new [`OsuFuture`] which might fetch a user first if the
+    /// given [`UserId`] is a name that has not been cached yet.
+    pub(crate) fn from_user_id(
+        osu: &Osu,
+        user_id: UserId,
+        from_user_data: T::FromUserData,
+        from_user_fn: FromUserFn<T>,
+        post_process_data: T::PostProcessData,
+        post_process_fn: PostProcessFn<T>,
+    ) -> Self {
+        #[cfg(not(feature = "cache"))]
+        let get_user_id: fn(UserId) -> UserId = std::convert::identity;
+
+        #[cfg(feature = "cache")]
+        fn get_user_id(mut user_id: UserId, osu: &Osu) -> UserId {
+            if let UserId::Name(ref mut name) = user_id {
+                name.make_ascii_lowercase();
+
+                if let Some(id) = osu.inner.cache.get(name) {
+                    return UserId::Id(*id);
+                }
+            }
+
+            user_id
+        }
+
+        match get_user_id(
+            user_id,
+            #[cfg(feature = "cache")]
+            osu,
+        ) {
+            UserId::Id(user_id) => {
+                let req = from_user_fn(user_id, from_user_data);
+
+                Self::new(osu, req, post_process_data, post_process_fn)
+            }
+            user_id @ UserId::Name(_) => {
+                #[cfg(not(feature = "cache"))]
+                {
+                    static NOTIF: std::sync::Once = std::sync::Once::new();
+
+                    // In case users intend to fetch frequently from user
+                    // endpoints by username but weren't aware either that
+                    // they have the `cache` feature disabled or that
+                    // disabling the feature will add an additional request
+                    // on every fetch, let's remind them a single time.
+                    NOTIF.call_once(|| {
+                        warn!(
+                            "Fetching from a user endpoint by username will \
+                            always perform two requests because the `cache` \
+                            feature is not enabled"
+                        );
+                    });
+                }
+
+                let osu = Arc::clone(&osu.inner);
+                let req = GetUser::create_request(user_id, None);
+
+                Self {
+                    stage: OsuRequestStageInner::new(osu, req)
+                        .map_or_else(OsuFutureStage::Failed, OsuFutureStage::User),
+                    from_user: Some(FromUser {
+                        data: from_user_data,
+                        f: from_user_fn,
+                    }),
+                    post_process: Some(PostProcess {
+                        data: post_process_data,
+                        f: post_process_fn,
+                    }),
+                }
+            }
+        }
+    }
+}
+
+impl<T: OsuFutureData> Future for OsuFuture<T> {
+    type Output = <T as IntoFuture>::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.as_mut().project();
+
+        match this.stage.as_mut().poll(cx) {
+            Poll::Ready(ControlFlow::Break(Ok((bytes, osu)))) => {
+                let res = <T::FromBytes>::from_bytes(bytes)?;
+                let PostProcess { data, f } =
+                    this.post_process.take().expect("missing post_process");
+
+                let value = f(res, data)?;
+
+                #[cfg(feature = "cache")]
+                crate::model::ContainedUsers::apply_to_users(&value, |id, name| {
+                    osu.update_cache(id, name);
+                });
+
+                // Preventing "unused variable" lint w/o `cache` feature
+                let _ = osu;
+
+                Poll::Ready(Ok(value))
+            }
+            Poll::Ready(ControlFlow::Continue((user, osu))) => {
+                #[cfg(feature = "cache")]
+                osu.update_cache(user.user_id, &user.username);
+
+                #[cfg(feature = "metrics")]
+                // Technically, using a gauge and setting it to
+                // `osu.cache.len()` would be more correct but since
+                // `DashMap::len` is a non-trivial call, it should be fine
+                // to increment a counter. This works because we're only in
+                // this path if the cache did not contain the username in
+                // the first place, meaning we indeed add a new entry.
+                ::metrics::counter!(crate::metrics::USERNAME_CACHE_SIZE).increment(1);
+
+                let FromUser { data, f } = this.from_user.take().expect("missing from_user");
+                let req = f(user.user_id, data);
+
+                let next = OsuRequestStageInner::new(osu, req)?;
+                this.stage.project_replace(OsuFutureStage::Final(next));
+
+                self.poll(cx)
+            }
+            Poll::Ready(ControlFlow::Break(Err(err))) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) const fn noop_post_process<T>(value: T, _: ()) -> OsuResult<T> {
+    Ok(value)
+}

--- a/src/future/request_generator.rs
+++ b/src/future/request_generator.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::{
+    header::{HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+    Request as HyperRequest,
+};
+use url::Url;
+
+use crate::{
+    client::OsuInner,
+    error::OsuError,
+    request::{Method, Request},
+    OsuResult,
+};
+
+pub(super) struct FutureRequestGenerator {
+    pub(super) osu: Arc<OsuInner>,
+    method: Method,
+    uri: Box<str>,
+    token: HeaderValue,
+    api_version: u32,
+    body: Vec<u8>,
+    pub(super) attempt: u8,
+    #[cfg(feature = "metrics")]
+    pub(super) route: &'static str,
+}
+
+pub(super) static MY_USER_AGENT: &str = concat!(
+    "Rust API v2 (",
+    env!("CARGO_PKG_REPOSITORY"),
+    " v",
+    env!("CARGO_PKG_VERSION"),
+    ")",
+);
+
+pub(super) const APPLICATION_JSON: &str = "application/json";
+pub(super) const X_API_VERSION: &str = "x-api-version";
+
+impl FutureRequestGenerator {
+    pub(super) fn new(osu: Arc<OsuInner>, req: Request) -> OsuResult<Self> {
+        let Request {
+            query,
+            route,
+            body,
+            api_version,
+        } = req;
+
+        let (method, path) = route.as_parts();
+
+        let mut url = format!("https://osu.ppy.sh/api/v2/{path}");
+
+        if let Some(ref query) = query {
+            url.push('?');
+            url.push_str(query);
+        }
+
+        let url = Url::parse(&url).map_err(|source| OsuError::Url { source, url })?;
+        debug!(%url, "Performing request...");
+
+        let token_res = osu.token.get(|token| match token.access {
+            Some(ref access) => match HeaderValue::from_str(access) {
+                Ok(header) => Ok(header),
+                Err(source) => Err(OsuError::CreatingTokenHeader { source }),
+            },
+            None => Err(OsuError::NoToken),
+        });
+
+        let token = token_res?;
+
+        // `Url`'s parsing allocates a string based on the input length so we
+        // are generally dealing with a `String` that has equal length and
+        // capacity meaning we don't re-allocate when boxing the string.
+        let uri = String::from(url).into_boxed_str();
+
+        Ok(Self {
+            osu,
+            method,
+            uri,
+            token,
+            api_version,
+            body: body.into_bytes(),
+            attempt: 0,
+            #[cfg(feature = "metrics")]
+            route: route.name(),
+        })
+    }
+
+    pub(super) fn generate(&self) -> OsuResult<HyperRequest<Full<Bytes>>> {
+        let len = self.body.len();
+
+        let mut req = HyperRequest::builder()
+            .method(self.method.into_hyper())
+            .uri(self.uri.as_ref())
+            .header(AUTHORIZATION, self.token.clone())
+            .header(USER_AGENT, MY_USER_AGENT)
+            .header(X_API_VERSION, self.api_version)
+            .header(ACCEPT, APPLICATION_JSON)
+            .header(CONTENT_LENGTH, len);
+
+        if len > 0 {
+            req = req.header(CONTENT_TYPE, APPLICATION_JSON);
+        }
+
+        let body = Full::new(Bytes::copy_from_slice(&self.body));
+
+        req.body(body).map_err(OsuError::from)
+    }
+}

--- a/src/future/stage.rs
+++ b/src/future/stage.rs
@@ -1,0 +1,339 @@
+use std::{
+    future::Future,
+    ops::ControlFlow,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+use http_body_util::{combinators::Collect, BodyExt};
+use hyper::{
+    body::{Bytes, Incoming},
+    Response as HyperResponse, StatusCode,
+};
+use hyper_util::client::legacy::ResponseFuture as HyperResponseFuture;
+use leaky_bucket::{AcquireOwned, RateLimiter};
+use pin_project::pin_project;
+use tokio::time::Timeout;
+
+use crate::{
+    client::OsuInner,
+    error::{ApiError, OsuError},
+    prelude::UserExtended,
+    request::Request,
+    OsuResult,
+};
+
+use super::request_generator::FutureRequestGenerator;
+
+#[pin_project]
+struct Ratelimit {
+    #[pin]
+    acquire: AcquireOwned,
+    generator: Option<FutureRequestGenerator>,
+}
+
+impl Ratelimit {
+    fn new(ratelimiter: Arc<RateLimiter>, generator: FutureRequestGenerator) -> Self {
+        Self {
+            acquire: ratelimiter.acquire_owned(1),
+            generator: Some(generator),
+        }
+    }
+}
+
+impl Future for Ratelimit {
+    type Output = FutureRequestGenerator;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.acquire.poll(cx) {
+            Poll::Ready(_) => Poll::Ready(this.generator.take().expect("missing generator")),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project]
+struct InFlight {
+    #[pin]
+    future: Timeout<HyperResponseFuture>,
+    generator: Option<FutureRequestGenerator>,
+    #[cfg(feature = "metrics")]
+    start: Option<Instant>,
+}
+
+impl InFlight {
+    fn new(future: HyperResponseFuture, generator: FutureRequestGenerator) -> Self {
+        Self {
+            future: tokio::time::timeout(generator.osu.timeout, future),
+            generator: Some(generator),
+            #[cfg(feature = "metrics")]
+            start: None,
+        }
+    }
+}
+
+enum InFlightOutput {
+    Ratelimit(Ratelimit),
+    Chunking(Chunking),
+    Failed(OsuError),
+}
+
+impl Future for InFlight {
+    type Output = InFlightOutput;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        #[cfg(feature = "metrics")]
+        let start = *this.start.get_or_insert_with(Instant::now);
+
+        match this.future.poll(cx) {
+            Poll::Ready(Ok(Ok(resp))) => {
+                let status = resp.status();
+
+                match status {
+                    StatusCode::NOT_FOUND => {
+                        return Poll::Ready(InFlightOutput::Failed(OsuError::NotFound))
+                    }
+                    StatusCode::SERVICE_UNAVAILABLE => {
+                        return Poll::Ready(InFlightOutput::Failed(OsuError::ServiceUnavailable {
+                            body: resp.into_body(),
+                        }))
+                    }
+                    StatusCode::TOO_MANY_REQUESTS => warn!("429 response: {resp:?}"),
+                    _ => {}
+                }
+
+                let generator = this.generator.take().expect("missing generator");
+
+                let chunking = Chunking::new(
+                    resp,
+                    generator.osu,
+                    #[cfg(feature = "metrics")]
+                    ChunkingMetrics {
+                        start,
+                        route: generator.route,
+                    },
+                );
+
+                Poll::Ready(InFlightOutput::Chunking(chunking))
+            }
+            Poll::Ready(Ok(Err(source))) => {
+                Poll::Ready(InFlightOutput::Failed(OsuError::Request { source }))
+            }
+            Poll::Ready(Err(_)) => {
+                let mut generator = this.generator.take().expect("missing generator");
+                let max_retries = generator.osu.retries;
+
+                if generator.attempt >= max_retries {
+                    return Poll::Ready(InFlightOutput::Failed(OsuError::RequestTimeout));
+                }
+
+                generator.attempt += 1;
+
+                warn!(
+                    "Timed out on attempt {}/{max_retries}, retrying...",
+                    generator.attempt
+                );
+
+                let ratelimiter = Arc::clone(&generator.osu.ratelimiter);
+
+                Poll::Ready(InFlightOutput::Ratelimit(Ratelimit::new(
+                    ratelimiter,
+                    generator,
+                )))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project]
+pub(super) struct Chunking {
+    #[pin]
+    future: Collect<Incoming>,
+    status: StatusCode,
+    osu: Arc<OsuInner>,
+    #[cfg(feature = "metrics")]
+    metrics: ChunkingMetrics,
+}
+
+#[cfg(feature = "metrics")]
+pub(super) struct ChunkingMetrics {
+    pub(super) start: Instant,
+    pub(super) route: &'static str,
+}
+
+impl Chunking {
+    pub(super) fn new(
+        resp: HyperResponse<Incoming>,
+        osu: Arc<OsuInner>,
+        #[cfg(feature = "metrics")] metrics: ChunkingMetrics,
+    ) -> Self {
+        Self {
+            status: resp.status(),
+            future: resp.into_body().collect(),
+            osu,
+            #[cfg(feature = "metrics")]
+            metrics,
+        }
+    }
+}
+
+impl Future for Chunking {
+    type Output = OsuResult<(Bytes, Arc<OsuInner>)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let bytes = match this.future.poll(cx) {
+            Poll::Ready(Ok(collected)) => collected.to_bytes(),
+            Poll::Ready(Err(source)) => {
+                return Poll::Ready(Err(OsuError::ChunkingResponse { source }));
+            }
+            Poll::Pending => return Poll::Pending,
+        };
+
+        #[cfg(feature = "metrics")]
+        ::metrics::histogram!(crate::metrics::RESPONSE_TIME, "route" => this.metrics.route)
+            .record(this.metrics.start.elapsed());
+
+        // let text = String::from_utf8_lossy(&bytes);
+        // println!("Response:\n{text}");
+
+        let status = *this.status;
+        let osu = Arc::clone(this.osu);
+
+        if status.is_success() {
+            return Poll::Ready(Ok((bytes, osu)));
+        }
+
+        let err = match serde_json::from_slice::<ApiError>(&bytes) {
+            Ok(source) => OsuError::Response {
+                bytes,
+                source,
+                status,
+            },
+            Err(source) => OsuError::Parsing { bytes, source },
+        };
+
+        Poll::Ready(Err(err))
+    }
+}
+
+#[pin_project(project = StageInnerProject, project_replace = StageInnerReplace)]
+#[allow(
+    private_interfaces,
+    reason = "we need this enum to be `pub(super)` solely to access its `new` \
+    method; not to use its variants"
+)]
+pub(super) enum OsuRequestStageInner {
+    Ratelimit(#[pin] Ratelimit),
+    InFlight(#[pin] InFlight),
+    Chunking(#[pin] Chunking),
+}
+
+impl OsuRequestStageInner {
+    pub(super) fn new(osu: Arc<OsuInner>, req: Request) -> OsuResult<Self> {
+        let ratelimiter = Arc::clone(&osu.ratelimiter);
+        let generator = FutureRequestGenerator::new(osu, req)?;
+
+        Ok(Self::Ratelimit(Ratelimit::new(ratelimiter, generator)))
+    }
+}
+
+impl Future for OsuRequestStageInner {
+    type Output = ControlFlow<Result<(Bytes, Arc<OsuInner>), OsuError>, OsuRequestStageInner>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            StageInnerProject::Ratelimit(ratelimit) => match ratelimit.poll(cx) {
+                Poll::Ready(generator) => match generator.generate() {
+                    Ok(req) => {
+                        let future = generator.osu.http.request(req);
+                        let in_flight = InFlight::new(future, generator);
+
+                        Poll::Ready(ControlFlow::Continue(Self::InFlight(in_flight)))
+                    }
+                    Err(err) => Poll::Ready(ControlFlow::Break(Err(err))),
+                },
+                Poll::Pending => Poll::Pending,
+            },
+            StageInnerProject::InFlight(in_flight) => match in_flight.poll(cx) {
+                Poll::Ready(InFlightOutput::Ratelimit(ratelimit)) => {
+                    Poll::Ready(ControlFlow::Continue(Self::Ratelimit(ratelimit)))
+                }
+                Poll::Ready(InFlightOutput::Chunking(chunking)) => {
+                    Poll::Ready(ControlFlow::Continue(Self::Chunking(chunking)))
+                }
+                Poll::Ready(InFlightOutput::Failed(err)) => {
+                    Poll::Ready(ControlFlow::Break(Err(err)))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            StageInnerProject::Chunking(chunking) => chunking.poll(cx).map(ControlFlow::Break),
+        }
+    }
+}
+
+#[pin_project(project = StageProject, project_replace = StageReplace)]
+pub(super) enum OsuFutureStage {
+    User(#[pin] OsuRequestStageInner),
+    Final(#[pin] OsuRequestStageInner),
+    Failed(OsuError),
+    Completed,
+}
+
+impl Future for OsuFutureStage {
+    type Output = ControlFlow<OsuResult<(Bytes, Arc<OsuInner>)>, (UserExtended, Arc<OsuInner>)>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            match self.as_mut().project() {
+                StageProject::User(mut stage) => match stage.as_mut().poll(cx) {
+                    Poll::Ready(ControlFlow::Continue(next)) => {
+                        stage.project_replace(next);
+                    }
+                    Poll::Ready(ControlFlow::Break(Ok((bytes, osu)))) => {
+                        return match serde_json::from_slice(&bytes) {
+                            Ok(user) => Poll::Ready(ControlFlow::Continue((user, osu))),
+                            Err(source) => {
+                                Poll::Ready(ControlFlow::Break(Err(OsuError::Parsing {
+                                    bytes,
+                                    source,
+                                })))
+                            }
+                        }
+                    }
+                    Poll::Ready(ControlFlow::Break(Err(err))) => {
+                        return Poll::Ready(ControlFlow::Break(Err(err)))
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                StageProject::Final(mut stage) => match stage.as_mut().poll(cx) {
+                    Poll::Ready(ControlFlow::Continue(next)) => {
+                        stage.project_replace(next);
+                    }
+                    Poll::Ready(ControlFlow::Break(res)) => {
+                        return Poll::Ready(ControlFlow::Break(res))
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                StageProject::Failed(_) => {
+                    let StageReplace::Failed(err) = self.project_replace(Self::Completed) else {
+                        unreachable!()
+                    };
+
+                    return Poll::Ready(ControlFlow::Break(Err(err)));
+                }
+                StageProject::Completed => panic!("future already completed"),
+            }
+        }
+    }
+}

--- a/src/future/token.rs
+++ b/src/future/token.rs
@@ -1,0 +1,212 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+use http_body_util::Full;
+use hyper::{
+    body::Bytes,
+    header::{ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+    Request as HyperRequest, StatusCode,
+};
+use hyper_util::client::legacy::ResponseFuture as HyperResponseFuture;
+use pin_project::pin_project;
+use tokio::time::Timeout;
+
+use crate::{
+    client::{Authorization, OsuInner, Scopes, TokenResponse},
+    error::OsuError,
+    request::JsonBody,
+    OsuResult,
+};
+
+use super::{
+    request_generator::{APPLICATION_JSON, MY_USER_AGENT},
+    stage::Chunking,
+};
+
+struct TokenRequestGenerator {
+    body: Vec<u8>,
+}
+
+impl TokenRequestGenerator {
+    fn new(osu: &OsuInner, mut body: JsonBody) -> Self {
+        body.push_int("client_id", osu.client_id);
+        body.push_str("client_secret", &osu.client_secret);
+
+        Self {
+            body: body.into_bytes(),
+        }
+    }
+
+    fn generate(self) -> OsuResult<HyperRequest<Full<Bytes>>> {
+        let len = self.body.len();
+        let body = Full::new(Bytes::from(self.body));
+        let url = "https://osu.ppy.sh/oauth/token";
+
+        HyperRequest::post(url)
+            .header(USER_AGENT, MY_USER_AGENT)
+            .header(ACCEPT, APPLICATION_JSON)
+            .header(CONTENT_TYPE, APPLICATION_JSON)
+            .header(CONTENT_LENGTH, len)
+            .body(body)
+            .map_err(OsuError::from)
+    }
+}
+
+#[pin_project]
+struct TokenInFlight {
+    #[pin]
+    future: Timeout<HyperResponseFuture>,
+    osu: Option<Arc<OsuInner>>,
+    #[cfg(feature = "metrics")]
+    start: Option<Instant>,
+}
+
+impl TokenInFlight {
+    fn new(future: HyperResponseFuture, osu: Arc<OsuInner>) -> Self {
+        Self {
+            future: tokio::time::timeout(osu.timeout, future),
+            osu: Some(osu),
+            #[cfg(feature = "metrics")]
+            start: None,
+        }
+    }
+}
+
+impl Future for TokenInFlight {
+    type Output = OsuResult<Chunking>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        #[cfg(feature = "metrics")]
+        let start = *this.start.get_or_insert_with(Instant::now);
+
+        match this.future.poll(cx) {
+            Poll::Ready(Ok(Ok(resp))) => {
+                match resp.status() {
+                    StatusCode::SERVICE_UNAVAILABLE => {
+                        return Poll::Ready(Err(OsuError::ServiceUnavailable {
+                            body: resp.into_body(),
+                        }))
+                    }
+                    StatusCode::TOO_MANY_REQUESTS => warn!("429 response: {resp:?}"),
+                    _ => {}
+                }
+
+                let osu = this.osu.take().expect("missing osu");
+
+                Poll::Ready(Ok(Chunking::new(
+                    resp,
+                    osu,
+                    #[cfg(feature = "metrics")]
+                    super::stage::ChunkingMetrics {
+                        start,
+                        route: "PostToken",
+                    },
+                )))
+            }
+            Poll::Ready(Ok(Err(source))) => Poll::Ready(Err(OsuError::Request { source })),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(OsuError::RequestTimeout)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project(project = TokenProject, project_replace = TokenReplace)]
+enum TokenFutureInner {
+    InFlight(#[pin] TokenInFlight),
+    Chunking(#[pin] Chunking),
+    Completed(Option<OsuError>),
+}
+
+#[pin_project]
+pub(crate) struct TokenFuture {
+    #[pin]
+    inner: TokenFutureInner,
+}
+
+impl TokenFuture {
+    pub(crate) fn new_client(osu: Arc<OsuInner>) -> Self {
+        let mut body = JsonBody::new();
+
+        body.push_str("grant_type", "client_credentials");
+        let mut scopes = String::new();
+        Scopes::Public.format(&mut scopes, ' ');
+        body.push_str("scope", &scopes);
+
+        Self::new(osu, body)
+    }
+
+    pub(crate) fn new_user(osu: Arc<OsuInner>, auth: &Authorization) -> Self {
+        let mut body = JsonBody::new();
+
+        body.push_str("grant_type", "authorization_code");
+        body.push_str("redirect_uri", &auth.redirect_uri);
+        body.push_str("code", &auth.code);
+        let mut scopes = String::new();
+        auth.scopes.format(&mut scopes, ' ');
+        body.push_str("scope", &scopes);
+
+        Self::new(osu, body)
+    }
+
+    pub(crate) fn new_refresh(osu: Arc<OsuInner>, refresh: &str) -> Self {
+        let mut body = JsonBody::new();
+
+        body.push_str("grant_type", "refresh_token");
+        body.push_str("refresh_token", refresh);
+
+        Self::new(osu, body)
+    }
+
+    fn new(osu: Arc<OsuInner>, body: JsonBody) -> Self {
+        let inner = match TokenRequestGenerator::new(&osu, body).generate() {
+            Ok(req) => TokenFutureInner::InFlight(TokenInFlight::new(osu.http.request(req), osu)),
+            Err(err) => TokenFutureInner::Completed(Some(err)),
+        };
+
+        Self { inner }
+    }
+}
+
+impl Future for TokenFuture {
+    type Output = OsuResult<TokenResponse>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.as_mut().project();
+
+        match this.inner.as_mut().project() {
+            TokenProject::InFlight(in_flight) => match in_flight.poll(cx) {
+                Poll::Ready(Ok(chunking)) => {
+                    this.inner
+                        .project_replace(TokenFutureInner::Chunking(chunking));
+
+                    self.poll(cx)
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                Poll::Pending => Poll::Pending,
+            },
+            TokenProject::Chunking(chunking) => match chunking.poll(cx) {
+                Poll::Ready(Ok((bytes, _))) => {
+                    let res = serde_json::from_slice(&bytes)
+                        .map_err(|source| OsuError::Parsing { bytes, source });
+
+                    Poll::Ready(res)
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                Poll::Pending => Poll::Pending,
+            },
+            TokenProject::Completed(err) => match err.take() {
+                Some(source) => Poll::Ready(Err(source)),
+                None => panic!("future already completed"),
+            },
+        }
+    }
+}

--- a/src/future/traits.rs
+++ b/src/future/traits.rs
@@ -1,0 +1,62 @@
+use std::future::IntoFuture;
+
+use bytes::Bytes;
+use serde::de::DeserializeOwned;
+
+use crate::{error::OsuError, model::ContainedUsers, request::Request, OsuResult};
+
+/// Converting `Self` into an [`OsuFuture<Self>`].
+///
+/// [`OsuFuture<Self>`]: crate::future::OsuFuture
+#[allow(
+    private_bounds,
+    reason = "users should not implement this trait anyway"
+)]
+pub trait OsuFutureData: IntoFuture<Output = OsuResult<Self::OsuOutput>> {
+    /// The received [`Bytes`] will be turned into this type.
+    type FromBytes: FromBytes;
+    /// Post processing will convert [`Self::FromBytes`] into this type.
+    type OsuOutput: ContainedUsers;
+    /// Auxiliary data to create a request from a user.
+    type FromUserData;
+    /// Auxiliary data used for post processing.
+    type PostProcessData;
+}
+
+/// Converting [`Bytes`] into `OsuResult<Self>`.
+pub(crate) trait FromBytes: Sized {
+    fn from_bytes(bytes: Bytes) -> OsuResult<Self>;
+}
+
+/// [`Bytes`] wrapper to implement [`FromBytes`] for bytes.
+#[doc(hidden)]
+pub struct BytesWrap(pub(crate) Bytes);
+
+impl FromBytes for BytesWrap {
+    fn from_bytes(bytes: Bytes) -> OsuResult<Self> {
+        Ok(Self(bytes))
+    }
+}
+
+impl<T: DeserializeOwned> FromBytes for T {
+    fn from_bytes(bytes: Bytes) -> OsuResult<Self> {
+        serde_json::from_slice(&bytes).map_err(|source| OsuError::Parsing { bytes, source })
+    }
+}
+
+/// Auxiliary trait to simplify logic within the [`into_future!`] macro.
+pub(crate) trait IntoPostProcessData<D> {
+    fn into_data(self) -> (Request, D);
+}
+
+impl IntoPostProcessData<()> for Request {
+    fn into_data(self) -> (Request, ()) {
+        (self, ())
+    }
+}
+
+impl<D> IntoPostProcessData<D> for (Request, D) {
+    fn into_data(self) -> (Request, D) {
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@
 //! | Flag          | Description                              | Dependencies
 //! | ------------- | ---------------------------------------- | ------------
 //! | `default`     | Enable the `cache` and `macros` features |
-//! | `cache`       | Cache username-user_id pairs so that usernames can be used on all user endpoints instead of only user ids | [`dashmap`]
+//! | `cache`       | Cache username-userid pairs so that fetching data by username does one instead of two requests | [`dashmap`]
 //! | `macros`      | Re-exports `rosu-mods`'s `mods!` macro to easily create mods for a given mode | [`paste`]
 //! | `serialize`   | Implement `serde::Serialize` for most types, allowing for manual serialization |
 //! | `metrics`     | Uses the global metrics registry to store response time for each endpoint | [`metrics`]
@@ -145,20 +145,21 @@
 )]
 
 mod client;
+mod future;
 mod routing;
 
-/// rosu-specific errors
+/// Errors types
 pub mod error;
 
 /// All available data types provided by the api
 pub mod model;
 
-/// Requesting-structs that implement [`Future`](std::future::Future) for each endpoint
+/// Request related types to fetch from endpoints
 pub mod request;
 
 mod metrics;
 
-pub use client::{Osu, OsuBuilder};
+pub use self::client::{Osu, OsuBuilder};
 
 #[macro_use]
 extern crate tracing;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,16 +2,19 @@
 
 use metrics::{describe_histogram, Unit};
 
+pub(crate) const RESPONSE_TIME: &str = "osu_response_time";
+pub(crate) const USERNAME_CACHE_SIZE: &str = "osu_username_cache_size";
+
 pub(crate) fn init_metrics() {
     describe_histogram!(
-        "osu_response_time",
+        RESPONSE_TIME,
         Unit::Seconds,
         "Response time for requests in seconds"
     );
 
     #[cfg(feature = "cache")]
     metrics::describe_counter!(
-        "osu_username_cache_size",
+        USERNAME_CACHE_SIZE,
         Unit::Count,
         "Number of cached usernames"
     );

--- a/src/model/comments.rs
+++ b/src/model/comments.rs
@@ -1,9 +1,11 @@
-use super::{serde_util, user::User};
-use crate::{prelude::Username, request::GetUser, Osu, OsuResult};
+use std::fmt;
 
 use serde::{Deserialize, Serializer};
-use std::fmt;
 use time::OffsetDateTime;
+
+use crate::{prelude::Username, request::GetUser, Osu, OsuResult};
+
+use super::{serde_util, user::User, CacheUserFn, ContainedUsers};
 
 /// Represents an single comment.
 #[derive(Clone, Debug, Deserialize)]
@@ -135,6 +137,12 @@ impl CommentBundle {
         debug_assert!(self.has_more == self.cursor.is_some());
 
         Some(osu.comments().cursor(self.cursor.as_deref()?).await)
+    }
+}
+
+impl ContainedUsers for CommentBundle {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.users.apply_to_users(f);
     }
 }
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -9,7 +9,7 @@ use super::{
     beatmap::RankStatus,
     serde_util,
     user::{Medal, Username},
-    GameMode, Grade,
+    CacheUserFn, ContainedUsers, GameMode, Grade,
 };
 
 #[derive(Clone, Debug, Deserialize)]
@@ -45,6 +45,12 @@ impl Events {
     }
 }
 
+impl ContainedUsers for Events {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.events.apply_to_users(f);
+    }
+}
+
 /// The object has different attributes depending on its type.
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -55,6 +61,10 @@ pub struct Event {
     pub event_id: u32,
     #[serde(flatten)]
     pub event_type: EventType,
+}
+
+impl ContainedUsers for Event {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/model/forum.rs
+++ b/src/model/forum.rs
@@ -1,11 +1,12 @@
-use super::serde_util;
+use std::fmt;
 
 use serde::{
     de::{Deserializer, Error, IgnoredAny, MapAccess, Visitor},
     Deserialize,
 };
-use std::fmt;
 use time::OffsetDateTime;
+
+use super::{serde_util, CacheUserFn, ContainedUsers};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -32,6 +33,10 @@ impl ForumPosts {
     pub const fn has_more(&self) -> bool {
         self.cursor.is_some()
     }
+}
+
+impl ContainedUsers for ForumPosts {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
 }
 
 #[derive(Clone, Debug)]

--- a/src/model/kudosu.rs
+++ b/src/model/kudosu.rs
@@ -3,6 +3,8 @@ use time::OffsetDateTime;
 
 use crate::model::user::Username;
 
+use super::{CacheUserFn, ContainedUsers};
+
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub enum KudosuAction {
@@ -40,6 +42,10 @@ pub struct KudosuHistory {
     pub giver: Option<KudosuGiver>,
     /// Simple detail of the object for display.
     pub post: KudosuPost,
+}
+
+impl ContainedUsers for KudosuHistory {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
 }
 
 impl PartialEq for KudosuHistory {

--- a/src/model/matches.rs
+++ b/src/model/matches.rs
@@ -1,12 +1,4 @@
-use super::{
-    beatmap::Beatmap,
-    mods::{GameMods, GameModsIntermode},
-    score::LegacyScoreStatistics,
-    serde_util,
-    user::User,
-    GameMode,
-};
-use crate::{error::OsuError, Osu, OsuResult};
+use std::{collections::HashMap, fmt, slice::Iter, vec::Drain};
 
 use rosu_mods::serde::GameModsSeed;
 use serde::{
@@ -16,8 +8,18 @@ use serde::{
     Deserialize,
 };
 use serde_json::value::RawValue;
-use std::{collections::HashMap, fmt, slice::Iter, vec::Drain};
 use time::OffsetDateTime;
+
+use crate::{error::OsuError, Osu, OsuResult};
+
+use super::{
+    beatmap::Beatmap,
+    mods::{GameMods, GameModsIntermode},
+    score::LegacyScoreStatistics,
+    serde_util,
+    user::User,
+    CacheUserFn, ContainedUsers, GameMode,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -516,6 +518,10 @@ impl MatchList {
     }
 }
 
+impl ContainedUsers for MatchList {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct MatchListParams {
@@ -683,6 +689,12 @@ pub struct OsuMatch {
     /// Maps user ids to users
     #[cfg_attr(feature = "serialize", serde(serialize_with = "serialize_match_users"))]
     pub users: HashMap<u32, User>,
+}
+
+impl ContainedUsers for OsuMatch {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.users.apply_to_users(f);
+    }
 }
 
 #[cfg(feature = "serialize")]

--- a/src/model/news.rs
+++ b/src/model/news.rs
@@ -1,9 +1,9 @@
-use super::serde_util;
+use serde::Deserialize;
+use time::OffsetDateTime;
+
 use crate::{prelude::Username, Osu, OsuResult};
 
-use serde::Deserialize;
-
-use time::OffsetDateTime;
+use super::{serde_util, CacheUserFn, ContainedUsers};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -35,6 +35,10 @@ impl News {
     pub async fn get_next(&self, osu: &Osu) -> Option<OsuResult<News>> {
         Some(osu.news().cursor(self.cursor.as_deref()?).await)
     }
+}
+
+impl ContainedUsers for News {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/model/seasonal_backgrounds.rs
+++ b/src/model/seasonal_backgrounds.rs
@@ -1,5 +1,6 @@
-use super::serde_util;
 use crate::model::user::User;
+
+use super::{serde_util, CacheUserFn, ContainedUsers};
 
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -15,6 +16,12 @@ pub struct SeasonalBackground {
     pub artist: User,
 }
 
+impl ContainedUsers for SeasonalBackground {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.artist.apply_to_users(f);
+    }
+}
+
 /// Collection of seasonal backgrounds
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -24,4 +31,10 @@ pub struct SeasonalBackgrounds {
     pub ends_at: OffsetDateTime,
     /// List of backgrounds
     pub backgrounds: Vec<SeasonalBackground>,
+}
+
+impl ContainedUsers for SeasonalBackgrounds {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.backgrounds.apply_to_users(f);
+    }
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,4 +1,4 @@
-use super::{serde_util, GameMode};
+use super::{serde_util, CacheUserFn, ContainedUsers, GameMode};
 
 use serde::{
     de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
@@ -500,6 +500,12 @@ pub struct UserExtended {
     pub medals: Option<Vec<MedalCompact>>,
 }
 
+impl ContainedUsers for UserExtended {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        f(self.user_id, &self.username);
+    }
+}
+
 /// Mainly used for embedding in certain responses to save additional api lookups.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -662,6 +668,12 @@ pub struct User {
     pub team: Option<Team>,
 }
 
+impl ContainedUsers for User {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        f(self.user_id, &self.username);
+    }
+}
+
 impl From<UserExtended> for User {
     fn from(user: UserExtended) -> Self {
         Self {
@@ -718,7 +730,8 @@ impl From<UserExtended> for User {
 }
 
 #[derive(Deserialize)]
-pub(crate) struct Users {
+#[doc(hidden)]
+pub struct Users {
     pub(crate) users: Vec<User>,
 }
 

--- a/src/model/wiki.rs
+++ b/src/model/wiki.rs
@@ -1,5 +1,7 @@
 use serde::Deserialize;
 
+use super::{CacheUserFn, ContainedUsers};
+
 /// Represents a wiki article
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -23,4 +25,8 @@ pub struct WikiPage {
     pub tags: Vec<String>,
     /// The article's title
     pub title: String,
+}
+
+impl ContainedUsers for WikiPage {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
 }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,24 +1,148 @@
-macro_rules! poll_req {
-    ($ty:ident => $ret:ty) => {
-        impl ::std::future::Future for $ty<'_> {
-            type Output = $crate::OsuResult<$ret>;
+/// Implements [`OsuFutureData`] and [`IntoFuture`] for requests.
+///
+/// [`OsuFutureData`]: crate::future::OsuFutureData
+/// [`IntoFuture`]: std::future::IntoFuture
+macro_rules! into_future {
+    // New OsuFuture with optional post processing
+    (
+        |$self:ident: $ty:ty| -> $from_bytes:ty { $( $req_body:tt )+ }
+        $( =>
+            |
+                $from_bytes_arg:tt,
+                $post_process_data_arg:tt $(: $post_process_data:ty )?
+            | -> $output:ty { $( $post_process_body:tt )+ }
+        )?
+    ) => {
+        impl crate::future::OsuFutureData for $ty {
+            type FromBytes = $from_bytes;
+            type OsuOutput = into_future!(OUTPUT_TY $from_bytes $( | $output )?);
+            type FromUserData = ();
+            type PostProcessData = into_future!(POST_PROCESS_DATA $( $( $post_process_data )? )?);
+        }
 
-            fn poll(
-                mut self: ::std::pin::Pin<&mut Self>,
-                cx: &mut ::std::task::Context<'_>,
-            ) -> ::std::task::Poll<Self::Output> {
-                match self.fut {
-                    Some(ref mut fut) => fut.as_mut().poll(cx),
-                    None => {
-                        let fut = self.start();
+        impl std::future::IntoFuture for $ty {
+            type Output = crate::OsuResult<into_future!(OUTPUT_TY $from_bytes $( | $output )?)>;
+            type IntoFuture = crate::future::OsuFuture<Self>;
 
-                        self.fut.get_or_insert(fut).as_mut().poll(cx)
-                    }
-                }
+            fn into_future($self) -> Self::IntoFuture {
+                let res = { $( $req_body )* };
+                let (req, data) =
+                    crate::future::IntoPostProcessData::into_data(res);
+
+                let post_process_fn = into_future!(POST_PROCESS_FN $(
+                    |
+                        $from_bytes_arg: $from_bytes,
+                        $post_process_data_arg $(: $post_process_data )?
+                    | { $( $post_process_body )* }
+                )?);
+
+                crate::future::OsuFuture::new(
+                    $self.osu,
+                    req,
+                    data,
+                    post_process_fn,
+                )
             }
         }
     };
+
+    // OsuFuture from UserId with optional post processing
+    (
+        |$self:ident: $ty:ty| -> $from_bytes:ty {
+            $from_user_data:ident {
+                $( $data_field_name:ident: $data_field_ty:ty = $data_field_value:expr, )*
+            }
+        } => |$user_id_arg:tt, $from_user_data_arg:tt| { $( $req_body:tt )* }
+        $(
+            => |$from_bytes_arg:tt, $post_process_data_arg:tt $(: $post_process_data:ty )?|
+                -> $output:ty { $( $post_process_body:tt )* }
+        )?
+    ) => {
+        #[doc(hidden)]
+        pub struct $from_user_data {
+            $( $data_field_name: $data_field_ty, )*
+        }
+
+        impl crate::future::OsuFutureData for $ty {
+            type FromBytes = $from_bytes;
+            type OsuOutput = into_future!(OUTPUT_TY $from_bytes $( | $output )?);
+            type FromUserData = $from_user_data;
+            type PostProcessData = into_future!(POST_PROCESS_DATA $( $( $post_process_data )? )?);
+        }
+
+        impl std::future::IntoFuture for $ty {
+            type Output = crate::OsuResult<into_future!(OUTPUT_TY $from_bytes $( | $output )?)>;
+            type IntoFuture = crate::future::OsuFuture<Self>;
+
+            fn into_future($self) -> Self::IntoFuture {
+                let from_user_data = $from_user_data {
+                    $( $data_field_name: $data_field_value, )*
+                };
+
+                let from_user_fn = |$user_id_arg: u32, $from_user_data_arg: $from_user_data| {
+                    $( $req_body )*
+                };
+
+                let post_process_fn = into_future!(POST_PROCESS_FN $(
+                    |
+                        $from_bytes_arg: $from_bytes,
+                        $post_process_data_arg $(: $post_process_data )?
+                    | { $( $post_process_body )* }
+                )?);
+
+                crate::future::OsuFuture::from_user_id(
+                    $self.osu,
+                    $self.user_id,
+                    from_user_data,
+                    from_user_fn,
+                    (), // FIXME: handle different post process data types
+                    post_process_fn,
+                )
+            }
+        }
+
+    };
+
+    // Helper rules
+
+    ( OUTPUT_TY $output:ty ) => {
+        $output
+    };
+    ( OUTPUT_TY $from_bytes:ty | $output:ty ) => {
+        $output
+    };
+    ( POST_PROCESS_DATA ) => {
+        ()
+    };
+    ( POST_PROCESS_DATA $data:ty ) => {
+        $data
+    };
+    ( POST_PROCESS_FN ) => {
+        crate::future::noop_post_process
+    };
+    ( POST_PROCESS_FN
+        |$from_bytes_arg:tt: $from_bytes:ty, $data_arg:tt $(: $data:ty )?|
+            { $( $post_process_body:tt )* }
+    ) => {
+        |
+            #[allow(unused_mut)]
+            mut $from_bytes_arg: $from_bytes,
+            $data_arg: into_future!(POST_PROCESS_DATA $( $data )?),
+        | { $( $post_process_body )* }
+    };
 }
+
+use itoa::{Buffer, Integer};
+use serde::Serialize;
+
+use crate::routing::Route;
+
+pub use crate::future::OsuFuture;
+
+pub use self::{
+    beatmap::*, comments::*, event::*, forum::*, matches::*, news::*, ranking::*, replay::*,
+    score::*, seasonal_backgrounds::*, user::*, wiki::*,
+};
 
 mod beatmap;
 mod comments;
@@ -34,27 +158,20 @@ mod serialize;
 mod user;
 mod wiki;
 
-pub use beatmap::*;
-use bytes::{Bytes, BytesMut};
-pub use comments::*;
-pub use event::*;
-pub use forum::*;
-pub use matches::*;
-pub use news::*;
-pub use ranking::*;
-pub use replay::*;
-pub use score::*;
-pub use seasonal_backgrounds::*;
-pub use user::*;
-pub use wiki::*;
+#[derive(Copy, Clone)]
+pub(crate) enum Method {
+    Get,
+    Post,
+}
 
-use crate::{routing::Route, OsuResult};
-
-use itoa::{Buffer, Integer};
-use serde::Serialize;
-use std::{future::Future, pin::Pin};
-
-type Pending<'a, T> = Pin<Box<dyn Future<Output = OsuResult<T>> + Send + Sync + 'a>>;
+impl Method {
+    pub const fn into_hyper(self) -> hyper::Method {
+        match self {
+            Method::Get => hyper::Method::GET,
+            Method::Post => hyper::Method::POST,
+        }
+    }
+}
 
 pub(crate) struct Request {
     pub query: Option<String>,
@@ -67,7 +184,7 @@ impl Request {
     #[allow(clippy::unreadable_literal)]
     const API_VERSION: u32 = 20220705;
 
-    fn new(route: Route) -> Self {
+    const fn new(route: Route) -> Self {
         Self::with_body(route, JsonBody::new())
     }
 
@@ -80,7 +197,7 @@ impl Request {
         }
     }
 
-    fn with_query(route: Route, query: String) -> Self {
+    const fn with_query(route: Route, query: String) -> Self {
         Self::with_query_and_body(route, query, JsonBody::new())
     }
 
@@ -99,32 +216,30 @@ impl Request {
 }
 
 pub(crate) struct JsonBody {
-    inner: BytesMut,
+    inner: Vec<u8>,
 }
 
 impl JsonBody {
-    pub(crate) fn new() -> Self {
-        Self {
-            inner: BytesMut::new(),
-        }
+    pub(crate) const fn new() -> Self {
+        Self { inner: Vec::new() }
     }
 
     fn push_prefix(&mut self) {
         let prefix = if self.inner.is_empty() { b'{' } else { b',' };
-        self.inner.extend_from_slice(&[prefix]);
+        self.inner.push(prefix);
     }
 
     fn push_key(&mut self, key: &[u8]) {
         self.push_prefix();
-        self.inner.extend_from_slice(b"\"");
+        self.inner.push(b'\"');
         self.inner.extend_from_slice(key);
         self.inner.extend_from_slice(b"\":");
     }
 
     fn push_value(&mut self, value: &[u8]) {
-        self.inner.extend_from_slice(b"\"");
+        self.inner.push(b'\"');
         self.inner.extend_from_slice(value);
-        self.inner.extend_from_slice(b"\"");
+        self.inner.push(b'\"');
     }
 
     pub(crate) fn push_str(&mut self, key: &str, value: &str) {
@@ -144,12 +259,12 @@ impl JsonBody {
         self.push_value(int.as_bytes());
     }
 
-    pub(crate) fn into_bytes(mut self) -> Bytes {
+    pub(crate) fn into_bytes(mut self) -> Vec<u8> {
         if !self.inner.is_empty() {
-            self.inner.extend_from_slice(b"}");
+            self.inner.push(b'}');
         }
 
-        self.inner.freeze()
+        self.inner
     }
 }
 

--- a/src/request/replay.rs
+++ b/src/request/replay.rs
@@ -1,32 +1,23 @@
-use futures::TryFutureExt;
-
-#[cfg(feature = "replay")]
-use futures::FutureExt;
-
-#[cfg(feature = "replay")]
-use osu_db::Replay;
-
 use crate::{
-    prelude::GameMode,
-    request::{Pending, Request},
+    future::BytesWrap,
+    model::{CacheUserFn, ContainedUsers, GameMode},
     routing::Route,
     Osu,
 };
 
-/// Get a raw replay in form of a `Vec<u8>`
-#[must_use = "futures do nothing unless you `.await` or poll them"]
+use super::Request;
+
+/// Get a raw replay as a `Vec<u8>`
+#[must_use = "requests must be configured and executed"]
 pub struct GetReplayRaw<'a> {
-    fut: Option<Pending<'a, Vec<u8>>>,
     osu: &'a Osu,
     mode: Option<GameMode>,
     score_id: u64,
 }
 
 impl<'a> GetReplayRaw<'a> {
-    #[inline]
-    pub(crate) fn new(osu: &'a Osu, score_id: u64) -> Self {
+    pub(crate) const fn new(osu: &'a Osu, score_id: u64) -> Self {
         Self {
-            fut: None,
             osu,
             mode: None,
             score_id,
@@ -40,56 +31,67 @@ impl<'a> GetReplayRaw<'a> {
 
         self
     }
+}
 
-    fn start(&mut self) -> Pending<'a, Vec<u8>> {
-        let route = Route::GetReplay {
+into_future! {
+    |self: GetReplayRaw<'_>| -> BytesWrap {
+        Request::new(Route::GetReplay {
             mode: self.mode,
             score_id: self.score_id,
-        };
-
-        let fut = self.osu.request_raw(Request::new(route)).map_ok(Vec::from);
-
-        Box::pin(fut)
+        })
+    } => |bytes, _| -> Vec<u8> {
+        Ok(Vec::from(bytes.0))
     }
 }
 
-poll_req!(GetReplayRaw => Vec<u8>);
+impl ContainedUsers for Vec<u8> {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
+}
 
-/// Get a [`Replay`](osu_db::Replay)
+/// Get a [`Replay`].
+///
+/// [`Replay`]: osu_db::Replay
 #[cfg(feature = "replay")]
 #[cfg_attr(docsrs, doc(cfg(feature = "replay")))]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[must_use = "requests must be configured and executed"]
 pub struct GetReplay<'a> {
-    fut: Option<Pending<'a, Replay>>,
-    inner: Option<GetReplayRaw<'a>>,
+    osu: &'a Osu,
+    mode: Option<GameMode>,
+    score_id: u64,
 }
 
 #[cfg(feature = "replay")]
 impl<'a> GetReplay<'a> {
-    #[inline]
-    pub(crate) fn new(osu: &'a Osu, score_id: u64) -> Self {
+    pub(crate) const fn new(osu: &'a Osu, score_id: u64) -> Self {
         Self {
-            fut: None,
-            inner: Some(GetReplayRaw::new(osu, score_id)),
+            osu,
+            mode: None,
+            score_id,
         }
     }
 
     /// Specify the mode
     #[inline]
-    pub fn mode(mut self, mode: GameMode) -> Self {
-        self.inner = self.inner.map(|raw| raw.mode(mode));
+    pub const fn mode(mut self, mode: GameMode) -> Self {
+        self.mode = Some(mode);
 
         self
-    }
-
-    fn start(&mut self) -> Pending<'a, Replay> {
-        let fut = self.inner.take().unwrap().map(|res| {
-            res.and_then(|bytes| Replay::from_bytes(&bytes).map_err(crate::error::OsuError::from))
-        });
-
-        Box::pin(fut)
     }
 }
 
 #[cfg(feature = "replay")]
-poll_req!(GetReplay => Replay);
+into_future! {
+    |self: GetReplay<'_>| -> BytesWrap {
+        Request::new(Route::GetReplay {
+            mode: self.mode,
+            score_id: self.score_id,
+        })
+    } => |bytes, _| -> osu_db::Replay {
+        osu_db::Replay::from_bytes(&bytes.0).map_err(crate::error::OsuError::from)
+    }
+}
+
+#[cfg(feature = "replay")]
+impl ContainedUsers for osu_db::Replay {
+    fn apply_to_users(&self, _: impl CacheUserFn) {}
+}

--- a/src/request/seasonal_backgrounds.rs
+++ b/src/request/seasonal_backgrounds.rs
@@ -1,28 +1,21 @@
 use crate::{
-    model::seasonal_backgrounds::SeasonalBackgrounds,
-    request::{Pending, Request},
-    routing::Route,
-    Osu,
+    model::seasonal_backgrounds::SeasonalBackgrounds, request::Request, routing::Route, Osu,
 };
 
 /// Get [`SeasonalBackgrounds`].
-#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[must_use = "requests must be configured and executed"]
 pub struct GetSeasonalBackgrounds<'a> {
-    fut: Option<Pending<'a, SeasonalBackgrounds>>,
     osu: &'a Osu,
 }
 
 impl<'a> GetSeasonalBackgrounds<'a> {
-    #[inline]
-    pub(crate) fn new(osu: &'a Osu) -> Self {
-        Self { fut: None, osu }
-    }
-
-    fn start(&mut self) -> Pending<'a, SeasonalBackgrounds> {
-        let req = Request::new(Route::GetSeasonalBackgrounds);
-
-        Box::pin(self.osu.request(req))
+    pub(crate) const fn new(osu: &'a Osu) -> Self {
+        Self { osu }
     }
 }
 
-poll_req!(GetSeasonalBackgrounds => SeasonalBackgrounds);
+into_future! {
+    |self: GetSeasonalBackgrounds<'_>| -> SeasonalBackgrounds {
+        Request::new(Route::GetSeasonalBackgrounds)
+    }
+}

--- a/src/request/serialize.rs
+++ b/src/request/serialize.rs
@@ -66,26 +66,14 @@ pub(crate) fn maybe_comment_sort<S: Serializer>(
     maybe(sort, serializer, CommentSort::serialize_as_query)
 }
 
-#[allow(clippy::ref_option)]
-pub(crate) fn maybe_user_id_type<S: Serializer>(
-    user_id: &Option<UserId>,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    maybe(user_id, serializer, user_id_type)
-}
-
 pub(crate) fn user_id_type<S: Serializer>(
-    #[cfg_attr(not(feature = "cache"), expect(unused_variables))] user_id: &UserId,
+    user_id: &UserId,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    #[cfg(feature = "cache")]
     match user_id {
         UserId::Id(_) => serializer.serialize_str("id"),
         UserId::Name(_) => serializer.serialize_str("username"),
     }
-
-    #[cfg(not(feature = "cache"))]
-    serializer.serialize_str("id")
 }
 
 #[allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,9 +1,8 @@
 use crate::{
     model::{ranking::RankingType, GameMode},
-    request::{ScoreType, UserId},
+    request::{Method, ScoreType, UserId},
 };
 
-use hyper::Method;
 use std::{borrow::Cow, fmt::Write};
 
 #[allow(clippy::enum_variant_names)]
@@ -79,7 +78,6 @@ pub(crate) enum Route {
         user_id: u32,
         score_type: ScoreType,
     },
-    #[allow(dead_code)]
     GetUsers,
     GetWikiPage {
         locale: Box<str>,
@@ -90,43 +88,43 @@ pub(crate) enum Route {
 impl Route {
     /// Separate a route into its parts: the HTTP method and the URI path.
     #[allow(clippy::too_many_lines)]
-    pub(crate) fn to_parts(&self) -> (Method, Cow<'static, str>) {
+    pub(crate) fn as_parts(&self) -> (Method, Cow<'static, str>) {
         match self {
-            Self::GetBeatmap => (Method::GET, "beatmaps/lookup".into()),
-            Self::GetBeatmaps => (Method::GET, "beatmaps".into()),
+            Self::GetBeatmap => (Method::Get, "beatmaps/lookup".into()),
+            Self::GetBeatmaps => (Method::Get, "beatmaps".into()),
             Self::PostBeatmapDifficultyAttributes { map_id } => {
-                (Method::POST, format!("beatmaps/{map_id}/attributes").into())
+                (Method::Post, format!("beatmaps/{map_id}/attributes").into())
             }
             Self::GetBeatmapScores { map_id } => {
-                (Method::GET, format!("beatmaps/{map_id}/scores").into())
+                (Method::Get, format!("beatmaps/{map_id}/scores").into())
             }
             Self::GetBeatmapUserScore { map_id, user_id } => (
-                Method::GET,
+                Method::Get,
                 format!("beatmaps/{map_id}/scores/users/{user_id}").into(),
             ),
             Self::GetBeatmapUserScores { map_id, user_id } => (
-                Method::GET,
+                Method::Get,
                 format!("beatmaps/{map_id}/scores/users/{user_id}/all").into(),
             ),
             Self::GetBeatmapset { mapset_id } => {
-                (Method::GET, format!("beatmapsets/{mapset_id}").into())
+                (Method::Get, format!("beatmapsets/{mapset_id}").into())
             }
-            Self::GetBeatmapsetFromMapId => (Method::GET, "beatmapsets/lookup".into()),
-            Self::GetBeatmapsetEvents => (Method::GET, "beatmapsets/events".into()),
-            Self::GetBeatmapsetSearch => (Method::GET, "beatmapsets/search".into()),
-            Self::GetComments => (Method::GET, "comments".into()),
-            Self::GetEvents => (Method::GET, "events".into()),
+            Self::GetBeatmapsetFromMapId => (Method::Get, "beatmapsets/lookup".into()),
+            Self::GetBeatmapsetEvents => (Method::Get, "beatmapsets/events".into()),
+            Self::GetBeatmapsetSearch => (Method::Get, "beatmapsets/search".into()),
+            Self::GetComments => (Method::Get, "comments".into()),
+            Self::GetEvents => (Method::Get, "events".into()),
             Self::GetForumPosts { topic_id } => {
-                (Method::GET, format!("forums/topics/{topic_id}").into())
+                (Method::Get, format!("forums/topics/{topic_id}").into())
             }
-            Self::GetFriends => (Method::GET, "friends".into()),
+            Self::GetFriends => (Method::Get, "friends".into()),
             Self::GetMatch { match_id } => {
                 let path = match match_id {
                     Some(id) => format!("matches/{id}").into(),
                     None => "matches".into(),
                 };
 
-                (Method::GET, path)
+                (Method::Get, path)
             }
             Self::GetNews { news } => {
                 let path = match news {
@@ -134,7 +132,7 @@ impl Route {
                     None => "news".into(),
                 };
 
-                (Method::GET, path)
+                (Method::Get, path)
             }
             Self::GetOwnData { mode } => {
                 let path = match mode {
@@ -142,14 +140,14 @@ impl Route {
                     None => "me".into(),
                 };
 
-                (Method::GET, path)
+                (Method::Get, path)
             }
             Self::GetRankings { mode, ranking_type } => (
-                Method::GET,
+                Method::Get,
                 format!("rankings/{mode}/{}", ranking_type.as_str()).into(),
             ),
             Self::GetRecentActivity { user_id } => (
-                Method::GET,
+                Method::Get,
                 format!("users/{user_id}/recent_activity").into(),
             ),
             Self::GetReplay { mode, score_id } => {
@@ -157,18 +155,18 @@ impl Route {
                     Some(mode) => format!("scores/{mode}/{score_id}/download").into(),
                     None => format!("scores/{score_id}/download").into(),
                 };
-                (Method::GET, path)
+                (Method::Get, path)
             }
             Self::GetScore { mode, score_id } => {
                 let path = match mode {
                     Some(mode) => format!("scores/{mode}/{score_id}").into(),
                     None => format!("scores/{score_id}").into(),
                 };
-                (Method::GET, path)
+                (Method::Get, path)
             }
-            Self::GetScores => (Method::GET, "scores".into()),
-            Self::GetSeasonalBackgrounds => (Method::GET, "seasonal-backgrounds".into()),
-            Self::GetSpotlights => (Method::GET, "spotlights".into()),
+            Self::GetScores => (Method::Get, "scores".into()),
+            Self::GetSeasonalBackgrounds => (Method::Get, "seasonal-backgrounds".into()),
+            Self::GetSpotlights => (Method::Get, "spotlights".into()),
             Self::GetUser { user_id, mode } => {
                 let mut path = format!("users/{user_id}");
 
@@ -176,23 +174,23 @@ impl Route {
                     let _ = write!(path, "/{mode}");
                 }
 
-                (Method::GET, path.into())
+                (Method::Get, path.into())
             }
             Self::GetUserBeatmapsets { user_id, map_type } => (
-                Method::GET,
+                Method::Get,
                 format!("users/{user_id}/beatmapsets/{map_type}").into(),
             ),
             Self::GetUserKudosu { user_id } => {
-                (Method::GET, format!("users/{user_id}/kudosu").into())
+                (Method::Get, format!("users/{user_id}/kudosu").into())
             }
             Self::GetUserScores {
                 user_id,
                 score_type,
             } => (
-                Method::GET,
+                Method::Get,
                 format!("users/{user_id}/scores/{}", score_type.as_str()).into(),
             ),
-            Self::GetUsers => (Method::GET, "users".into()),
+            Self::GetUsers => (Method::Get, "users".into()),
             Self::GetWikiPage { locale, page } => {
                 let mut path = format!("wiki/{locale}/");
 
@@ -200,7 +198,7 @@ impl Route {
                     path.push_str(page);
                 }
 
-                (Method::GET, path.into())
+                (Method::Get, path.into())
             }
         }
     }

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -344,7 +344,6 @@ async fn forum_posts() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "cache")]
 #[tokio::test]
 async fn recent_activity() -> Result<()> {
     let events = OSU
@@ -530,7 +529,6 @@ async fn team_rankings() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "cache")]
 #[tokio::test]
 async fn user() -> Result<()> {
     let user = OSU
@@ -586,7 +584,6 @@ async fn user_most_played() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "cache")]
 #[tokio::test]
 async fn user_scores() -> Result<()> {
     let scores = OSU


### PR DESCRIPTION
Instead of allocating anonymous futures for all endpoints, this PR implements a manual state machine for a common `OsuFuture`. This avoids the allocations, reduces the sizes of endpoint types and their futures, and likely reduces binary size by refactoring generics.

Also improves the username-userid caching by checking fetched data more thoroughly for such pairs.

Breaking changes:
- Endpoint structs (e.g. `GetUser`, `GetBeatmapScores`, ...) no longer implement `Future` and instead implement `IntoFuture`
- Methods on `Osu` that required, without the `cache` feature, a user id as `u32` now accept `Into<UserId>`. That is because user endpoints can now be used by username even without the `cache` feature enabled at the cost of *always* performing two requests by first fetching the user and then using that user's id to do the actual request.
- Replaced the variant field `OsuError::Parsing.body: String` with `bytes: Bytes`, same for `OsuError::Response`
- The variant `OsuError::ServiceUnavailable` now contains a `body: hyper::body::Incoming` field instead of an unnamed `String`.