### PR TITLE
refactor!: single list field deserialization

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -79,7 +79,7 @@ impl Osu {
         GetBeatmaps::new(self, map_ids)
     }
 
-    /// Get a vec of [`Score`](crate::model::score::Score).
+    /// Get [`BeatmapScores`](crate::model::beatmap::BeatmapScores).
     ///
     /// The contained scores will have the following options filled:
     /// `pp` (if ranked or approved), and `user`.

--- a/src/model/beatmap.rs
+++ b/src/model/beatmap.rs
@@ -17,7 +17,7 @@ use crate::{
     Osu, OsuResult,
 };
 
-use super::{serde_util, user::User, CacheUserFn, ContainedUsers, GameMode};
+use super::{score::Score, serde_util, user::User, CacheUserFn, ContainedUsers, GameMode};
 
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -165,13 +165,6 @@ impl From<BeatmapExtended> for Beatmap {
             version: map.version,
         }
     }
-}
-
-#[derive(Deserialize)]
-#[doc(hidden)]
-pub struct Beatmaps {
-    #[serde(rename = "beatmaps")]
-    pub(crate) maps: Vec<Beatmap>,
 }
 
 #[derive(Deserialize)]
@@ -1053,6 +1046,18 @@ pub struct BeatmapsetPost {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BeatmapsetReviewsConfig {
     pub max_blocks: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct BeatmapScores {
+    pub score_count: usize,
+    pub scores: Vec<Score>,
+}
+
+impl ContainedUsers for BeatmapScores {
+    fn apply_to_users(&self, f: impl CacheUserFn) {
+        self.scores.apply_to_users(f);
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -178,7 +178,7 @@ use std::{collections::HashMap, marker::PhantomData};
 
 pub use rosu_mods::GameMode;
 
-pub use self::grade::Grade;
+pub use self::{grade::Grade, serde_util::DeserializedList};
 
 use self::user::Username;
 

--- a/src/model/score.rs
+++ b/src/model/score.rs
@@ -16,12 +16,6 @@ use super::{
     CacheUserFn, ContainedUsers, GameMode, Grade,
 };
 
-#[derive(Debug, Deserialize)]
-#[doc(hidden)]
-pub struct BeatmapScores {
-    pub(crate) scores: Vec<Score>,
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct BeatmapUserScore {
@@ -346,12 +340,6 @@ impl PartialEq for Score {
 }
 
 impl Eq for Score {}
-
-#[derive(Deserialize)]
-#[doc(hidden)]
-pub struct Scores {
-    pub(crate) scores: Vec<Score>,
-}
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -729,12 +729,6 @@ impl From<UserExtended> for User {
     }
 }
 
-#[derive(Deserialize)]
-#[doc(hidden)]
-pub struct Users {
-    pub(crate) users: Vec<User>,
-}
-
 /// Specifies the type of mapsets returned by [`Osu::user_beatmapsets`].
 ///
 /// [`Osu::user_beatmapsets`]: crate::Osu::user_beatmapsets

--- a/src/request/beatmap.rs
+++ b/src/request/beatmap.rs
@@ -1,14 +1,15 @@
 use crate::{
     model::{
         beatmap::{
-            BeatmapDifficultyAttributes, BeatmapDifficultyAttributesWrapper, BeatmapExtended,
-            Beatmaps, BeatmapsetEvents, BeatmapsetExtended, BeatmapsetSearchResult,
-            BeatmapsetSearchSort, Genre, Language, RankStatus, SearchRankStatus,
+            Beatmap, BeatmapDifficultyAttributes, BeatmapDifficultyAttributesWrapper,
+            BeatmapExtended, BeatmapScores, BeatmapsetEvents, BeatmapsetExtended,
+            BeatmapsetSearchParameters, BeatmapsetSearchResult, BeatmapsetSearchSort, Genre,
+            Language, RankStatus, SearchRankStatus,
         },
-        score::{BeatmapScores, BeatmapUserScore, Score, Scores},
-        GameMode,
+        score::{BeatmapUserScore, Score},
+        DeserializedList, GameMode,
     },
-    prelude::{Beatmap, BeatmapsetSearchParameters, GameModsIntermode},
+    prelude::GameModsIntermode,
     request::{
         serialize::{maybe_mode_as_str, maybe_mods_as_list},
         Query, Request,
@@ -109,10 +110,10 @@ impl<'a> GetBeatmaps<'a> {
 }
 
 into_future! {
-    |self: GetBeatmaps<'_>| -> Beatmaps {
+    |self: GetBeatmaps<'_>| -> DeserializedList<Beatmap> {
         Request::with_query(Route::GetBeatmaps, self.query)
     } => |maps, _| -> Vec<Beatmap> {
-        Ok(maps.maps)
+        Ok(maps.0)
     }
 }
 
@@ -198,7 +199,7 @@ impl Serialize for ScoreType {
     }
 }
 
-/// Get top scores of a beatmap as a vec of [`Score`]s.
+/// Get top scores of a beatmap as [`BeatmapScores`].
 #[must_use = "requests must be configured and executed"]
 #[derive(Serialize)]
 pub struct GetBeatmapScores<'a> {
@@ -311,8 +312,6 @@ into_future! {
         }
 
         req
-    } => |scores, _| -> Vec<Score> {
-        Ok(scores.scores)
     }
 }
 
@@ -466,7 +465,7 @@ impl<'a> GetBeatmapUserScores<'a> {
 }
 
 into_future! {
-    |self: GetBeatmapUserScores<'_>| -> Scores {
+    |self: GetBeatmapUserScores<'_>| -> DeserializedList<Score> {
         GetBeatmapUserScoresData {
             query: String = Query::encode(&self),
             map_id: u32 = self.map_id,
@@ -484,7 +483,7 @@ into_future! {
 
         req
     } => |scores, _| -> Vec<Score> {
-        Ok(scores.scores)
+        Ok(scores.0)
     }
 }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -100,7 +100,6 @@ macro_rules! into_future {
                 )
             }
         }
-
     };
 
     // Helper rules

--- a/src/request/ranking.rs
+++ b/src/request/ranking.rs
@@ -2,7 +2,7 @@ use crate::{
     model::{
         ranking::{ChartRankings, CountryRankings, RankingType, Rankings, Spotlight},
         user::CountryCode,
-        GameMode,
+        DeserializedList, GameMode,
     },
     prelude::TeamRankings,
     request::{Query, Request},
@@ -10,7 +10,7 @@ use crate::{
     Osu,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Get a [`ChartRankings`] struct containing a [`Spotlight`], its
 /// [`BeatmapsetExtended`]s, and participating [`User`]s.
@@ -255,17 +255,11 @@ impl<'a> GetSpotlights<'a> {
 }
 
 into_future! {
-    |self: GetSpotlights<'_>| -> Spotlights {
+    |self: GetSpotlights<'_>| -> DeserializedList<Spotlight> {
         Request::new(Route::GetSpotlights)
-    } => |s, _| -> Vec<Spotlight> {
-        Ok(s.spotlights)
+    } => |spotlights, _| -> Vec<Spotlight> {
+        Ok(spotlights.0)
     }
-}
-
-#[derive(Deserialize)]
-#[doc(hidden)]
-pub struct Spotlights {
-    spotlights: Vec<Spotlight>,
 }
 
 /// Get a [`TeamRankings`] struct whose entries are sorted by their pp.

--- a/src/request/user.rs
+++ b/src/request/user.rs
@@ -10,8 +10,8 @@ use crate::{
         event::Event,
         kudosu::KudosuHistory,
         score::Score,
-        user::{User, UserBeatmapsetsKind, UserExtended, Username, Users},
-        GameMode,
+        user::{User, UserBeatmapsetsKind, UserExtended, Username},
+        DeserializedList, GameMode,
     },
     request::{
         serialize::{maybe_bool_as_u8, maybe_mode_as_str, user_id_type},
@@ -610,9 +610,9 @@ impl<'a> GetUsers<'a> {
 }
 
 into_future! {
-    |self: GetUsers<'_>| -> Users {
+    |self: GetUsers<'_>| -> DeserializedList<User> {
         Request::with_query(Route::GetUsers, self.query)
     } => |users, _| -> Vec<User> {
-        Ok(users.users)
+        Ok(users.0)
     }
 }

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -133,7 +133,12 @@ async fn beatmaps() -> Result<()> {
 #[tokio::test]
 async fn beatmap_scores() -> Result<()> {
     let scores = OSU.get().await?.beatmap_scores(ADESSO_BALLA).await?;
-    println!("Received {} scores", scores.len());
+
+    println!(
+        "Received {}/{} scores",
+        scores.scores.len(),
+        scores.score_count
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Refactors deserialization of single-list-field-structs into a generic type.

Evidently, the beatmap scores endpoint not only returns a list of scores, but also how many scores there are in total on a map so the `Osu::beatmap_scores` no longer results in a `Vec<Score>` but in the new struct `BeatmapScores`.