### PR TITLE
feat: add more room endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The following endpoints are currently supported:
 - `news`: Recent news
 - `rankings/{mode}/{ranking_type}`: The global leaderboard of either performance points, ranked score, countries, or a spotlight
 - `rooms`: Multiplayer rooms
+- `rooms/{room_id}`: A specific multiplayer room
+- `rooms/{room_id}/events`: Events for a multiplayer room
+- `rooms/{room_id}/leaderboard`: The leaderboard for a multiplayer room
 - `users/{user_id}/{recent_activity}`: List of a user's recent events like achieved medals, ranks on a beatmaps, username changes, supporter status updates, beatmapset status updates, ...
 - `scores/{mode}/{score_id}`: A specific score including its beatmap, beatmapset, and user
 - `scores`: Up to 1000 most recently processed scores (passes)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -324,13 +324,13 @@ impl Osu {
         GetRoom::new(self, room_id)
     }
 
-    /// TODO: docs
+    /// Get [`RoomEvents`](crate::model::multiplayer::RoomEvents).
     #[inline]
     pub const fn room_events(&self, room_id: u64) -> GetRoomEvents<'_> {
         GetRoomEvents::new(self, room_id)
     }
 
-    /// TODO: docs
+    /// Get a [`RoomLeaderboard`](crate::model::multiplayer::RoomLeaderboard).
     #[inline]
     pub const fn room_leaderboard(&self, room_id: u64) -> GetRoomLeaderboard<'_> {
         GetRoomLeaderboard::new(self, room_id)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -318,6 +318,24 @@ impl Osu {
         GetReplayRaw::new(self, score_id)
     }
 
+    /// Get a [`Room`](crate::model::multiplayer::Room).
+    #[inline]
+    pub const fn room(&self, room_id: u64) -> GetRoom<'_> {
+        GetRoom::new(self, room_id)
+    }
+
+    /// TODO: docs
+    #[inline]
+    pub const fn room_events(&self, room_id: u64) -> GetRoomEvents<'_> {
+        GetRoomEvents::new(self, room_id)
+    }
+
+    /// TODO: docs
+    #[inline]
+    pub const fn room_leaderboard(&self, room_id: u64) -> GetRoomLeaderboard<'_> {
+        GetRoomLeaderboard::new(self, room_id)
+    }
+
     /// Get a vec of [`Room`](crate::model::multiplayer::Room).
     #[inline]
     pub const fn rooms(&self) -> GetRooms<'_> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@
 //! - `news`: Recent news
 //! - `rankings/{mode}/{ranking_type}`: The global leaderboard of either performance points, ranked score, countries, or a spotlight
 //! - `rooms`: Multiplayer rooms
+//! - `rooms/{room_id}`: A specific multiplayer room
+//! - `rooms/{room_id}/events`: Events for a multiplayer room
+//! - `rooms/{room_id}/leaderboard`: The leaderboard for a multiplayer room
 //! - `users/{user_id}/{recent_activity}`: List of a user's recent events like achieved medals, ranks on a beatmaps, username changes, supporter status updates, beatmapset status updates, ...
 //! - `scores/{mode}/{score_id}`: A specific score including its beatmap, beatmapset, and user
 //! - `scores`: Up to 1000 most recently processed scores (passes)

--- a/src/model/multiplayer.rs
+++ b/src/model/multiplayer.rs
@@ -147,12 +147,12 @@ pub struct Room {
 
 impl Room {
     /// Get the [`RoomEvents`] for this [`Room`].
-    pub fn get_events<'osu>(&self, osu: &'osu Osu) -> GetRoomEvents<'osu> {
+    pub const fn get_events<'osu>(&self, osu: &'osu Osu) -> GetRoomEvents<'osu> {
         osu.room_events(self.room_id)
     }
 
     /// Get the [`RoomLeaderboard`] for this [`Room`].
-    pub fn get_leaderboard<'osu>(&self, osu: &'osu Osu) -> GetRoomLeaderboard<'osu> {
+    pub const fn get_leaderboard<'osu>(&self, osu: &'osu Osu) -> GetRoomLeaderboard<'osu> {
         osu.room_leaderboard(self.room_id)
     }
 }

--- a/src/model/multiplayer.rs
+++ b/src/model/multiplayer.rs
@@ -184,6 +184,7 @@ pub struct RoomDifficultyRange {
     pub max: f32,
 }
 
+/// An event of a [`Room`].
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct RoomEvent {
@@ -197,6 +198,7 @@ pub struct RoomEvent {
     pub user_id: Option<u32>,
 }
 
+/// The type of a [`RoomEvent`].
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[serde(rename_all = "snake_case")]
@@ -213,6 +215,7 @@ pub enum RoomEventKind {
     Unknown,
 }
 
+/// Events of a [`Room`].
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct RoomEvents {
@@ -255,6 +258,7 @@ impl ContainedUsers for RoomEvents {
     }
 }
 
+/// The leaderboard of a [`Room`].
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct RoomLeaderboard {
@@ -280,6 +284,7 @@ pub enum RoomQueueMode {
     HostOnly,
 }
 
+/// A score within a [`RoomLeaderboard`].
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 pub struct RoomScore {

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -56,6 +56,15 @@ pub(crate) enum Route {
         mode: Option<GameMode>,
         score_id: u64,
     },
+    GetRoom {
+        room_id: u64,
+    },
+    GetRoomEvents {
+        room_id: u64,
+    },
+    GetRoomLeaderboard {
+        room_id: u64,
+    },
     GetRooms,
     GetScore {
         mode: Option<GameMode>,
@@ -158,6 +167,13 @@ impl Route {
                 };
                 (Method::Get, path)
             }
+            Self::GetRoom { room_id } => (Method::Get, format!("rooms/{room_id}").into()),
+            Self::GetRoomEvents { room_id } => {
+                (Method::Get, format!("rooms/{room_id}/events").into())
+            }
+            Self::GetRoomLeaderboard { room_id } => {
+                (Method::Get, format!("rooms/{room_id}/leaderboard").into())
+            }
             Self::GetRooms => (Method::Get, "rooms".into()),
             Self::GetScore { mode, score_id } => {
                 let path = match mode {
@@ -237,6 +253,9 @@ impl Route {
             },
             Self::GetRecentActivity { .. } => "GetRecentActivity",
             Self::GetReplay { .. } => "GetReplay",
+            Self::GetRoom { .. } => "GetRoom",
+            Self::GetRoomEvents { .. } => "GetRoomEvents",
+            Self::GetRoomLeaderboard { .. } => "GetRoomLeaderboard",
             Self::GetRooms => "GetRooms",
             Self::GetScore { .. } => "GetScore",
             Self::GetScores => "GetScores",

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -497,6 +497,22 @@ async fn rooms() -> Result<()> {
 }
 
 #[tokio::test]
+async fn room() -> Result<()> {
+    let room = OSU.get().await?.room(1403108).await?;
+    println!("Received room {:?}", room.name);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn room_leaderboard() -> Result<()> {
+    let res = OSU.get().await?.room_leaderboard(1403108).await?;
+    println!("Received {} room scores", res.leaderboard.len());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn score() -> Result<()> {
     let score = OSU.get().await?.score(COOKIEZI_FREEDOM_DIVE).await?;
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -597,15 +597,16 @@ mod types {
             current_playlist_item: Some(get_playlist_item()),
             host: get_user(),
             recent_participants: vec![get_user()],
-            playlist_item_stats: PlaylistItemStats {
+            playlist_item_stats: Some(PlaylistItemStats {
                 count_active: 4,
                 count_total: 5,
                 modes: vec![GameMode::Taiko, GameMode::Mania],
-            },
-            difficulty_range: RoomDifficultyRange {
+            }),
+            difficulty_range: Some(RoomDifficultyRange {
                 min: 12.34,
                 max: 3.1419,
-            },
+            }),
+            playlist: vec![get_playlist_item()],
         }
     }
 
@@ -636,6 +637,7 @@ mod types {
             .into_iter()
             .collect(),
             required_mods: GameMods::new(),
+            scores: vec![get_score()],
         }
     }
 


### PR DESCRIPTION
Building onto #58, this adds the methods `Osu::room`,`Osu::room_events`, and `Osu::room_leaderboard`.