### PR TITLE
feat!: add playlist scores endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following endpoints are currently supported:
 - `rooms/{room_id}`: A specific multiplayer room
 - `rooms/{room_id}/events`: Events for a multiplayer room
 - `rooms/{room_id}/leaderboard`: The leaderboard for a multiplayer room
+- `rooms/{room_id}/playlist/{playlist_id}/scores`: Scores of a room's playlist
 - `users/{user_id}/{recent_activity}`: List of a user's recent events like achieved medals, ranks on a beatmaps, username changes, supporter status updates, beatmapset status updates, ...
 - `scores/{mode}/{score_id}`: A specific score including its beatmap, beatmapset, and user
 - `scores`: Up to 1000 most recently processed scores (passes)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -297,6 +297,12 @@ impl Osu {
         GetPerformanceRankings::new(self, mode)
     }
 
+    /// Get [`PlaylistScores`](crate::model::multiplayer::PlaylistScores).
+    #[inline]
+    pub const fn playlist_scores(&self, room_id: u64, playlist_id: u32) -> GetPlaylistScores<'_> {
+        GetPlaylistScores::new(self, room_id, playlist_id)
+    }
+
     /// Get the recent activity of a user in form of a vec of
     /// [`Event`](crate::model::event::Event)s.
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 //! - `rooms/{room_id}`: A specific multiplayer room
 //! - `rooms/{room_id}/events`: Events for a multiplayer room
 //! - `rooms/{room_id}/leaderboard`: The leaderboard for a multiplayer room
+//! - `rooms/{room_id}/playlist/{playlist_id}/scores`: Scores of a room's playlist
 //! - `users/{user_id}/{recent_activity}`: List of a user's recent events like achieved medals, ranks on a beatmaps, username changes, supporter status updates, beatmapset status updates, ...
 //! - `scores/{mode}/{score_id}`: A specific score including its beatmap, beatmapset, and user
 //! - `scores`: Up to 1000 most recently processed scores (passes)

--- a/src/model/score.rs
+++ b/src/model/score.rs
@@ -121,6 +121,8 @@ pub struct Score {
     pub rank_global: Option<u32>,
     pub user: Option<Box<User>>,
     pub weight: Option<ScoreWeight>,
+    pub playlist_item_id: Option<u32>,
+    pub room_id: Option<u64>,
 }
 
 impl ContainedUsers for Score {
@@ -191,6 +193,13 @@ impl<'de> Deserialize<'de> for Score {
             // TODO: This is just a temporary fix for <https://github.com/ppy/osu-web/issues/10932>.
             // Once the issue is resolved, `Option<ScoreWeight>` can be used again.
             weight: Option<MaybeWeight>,
+            playlist_item_id: Option<u32>,
+            room_id: Option<u64>,
+            #[expect(
+                unused,
+                reason = "should be the same as `score_id`; only available for playlist scores"
+            )]
+            solo_score_id: Option<u64>,
         }
 
         #[derive(Deserialize)]
@@ -264,6 +273,8 @@ impl<'de> Deserialize<'de> for Score {
                     pp: weight.pp?,
                 })
             }),
+            playlist_item_id: score_raw.playlist_item_id,
+            room_id: score_raw.room_id,
         })
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -45,6 +45,10 @@ pub(crate) enum Route {
     GetOwnData {
         mode: Option<GameMode>,
     },
+    GetPlaylistScores {
+        room_id: u64,
+        playlist_id: u32,
+    },
     GetRankings {
         mode: GameMode,
         ranking_type: RankingType,
@@ -152,6 +156,13 @@ impl Route {
 
                 (Method::Get, path)
             }
+            Self::GetPlaylistScores {
+                room_id,
+                playlist_id,
+            } => (
+                Method::Get,
+                format!("rooms/{room_id}/playlist/{playlist_id}/scores").into(),
+            ),
             Self::GetRankings { mode, ranking_type } => (
                 Method::Get,
                 format!("rankings/{mode}/{}", ranking_type.as_str()).into(),
@@ -244,6 +255,7 @@ impl Route {
             },
             Self::GetNews { .. } => "GetNews",
             Self::GetOwnData { .. } => "GetOwnData",
+            Self::GetPlaylistScores { .. } => "GetPlaylistScores",
             Self::GetRankings { ranking_type, .. } => match ranking_type {
                 RankingType::Charts => "GetRankings/Charts",
                 RankingType::Country => "GetRankings/Country",

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -14,7 +14,7 @@ use rosu_v2::{
         event::EventSort,
         GameMode,
     },
-    prelude::{RoomCategory, RoomTypeGroup, UserBeatmapsetsKind},
+    prelude::{PlaylistScoresSort, RoomCategory, RoomTypeGroup, UserBeatmapsetsKind},
     request::{RoomsFilter, RoomsTypeGroup},
     Osu,
 };
@@ -440,6 +440,37 @@ async fn performance_rankings() -> Result<()> {
         "Received performance rankings with {} out of {} users",
         rankings.ranking.len(),
         rankings.total
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn playlist_scores() -> Result<()> {
+    let osu = OSU.get().await?;
+
+    let room = osu
+        .rooms()
+        .category(RoomCategory::DailyChallenge)
+        .filter(RoomsFilter::Active)
+        .await?
+        .pop()
+        .unwrap();
+
+    let playlist_item_id = room.current_playlist_item.unwrap().playlist_item_id;
+
+    let scores = osu
+        .playlist_scores(room.room_id, playlist_item_id)
+        .limit(2)
+        .sort(PlaylistScoresSort::Ascending)
+        .await?;
+
+    let next = scores.get_next(&osu).await.unwrap()?;
+
+    println!(
+        "Got {} and {} scores",
+        scores.scores.len(),
+        next.scores.len()
     );
 
     Ok(())

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -730,6 +730,8 @@ mod types {
             legacy_score: 765_432_198,
             started_at: Some(get_date()),
             current_user_attributes: UserAttributes { pin: None },
+            playlist_item_id: Some(999),
+            room_id: Some(888),
         }
     }
 


### PR DESCRIPTION
Adds the method `Osu::playlist_scores`.

Breaking change: Adds the fields `playlist_item_id` and `room_id` to `Score`.