### PR TITLE
fix: Allow cursor_string to be null in PlaylistScores

### DIFF
--- a/src/model/multiplayer.rs
+++ b/src/model/multiplayer.rs
@@ -125,7 +125,7 @@ pub struct PlaylistScores {
     pub total: usize,
     pub user_score: Option<Score>,
     #[serde(rename = "cursor_string")]
-    pub cursor: Box<str>,
+    pub cursor: Option<Box<str>>,
 }
 
 impl PlaylistScores {
@@ -141,7 +141,12 @@ impl PlaylistScores {
             .playlist_scores(self.room_id, self.playlist_id)
             .limit(self.params.limit)
             .sort(self.params.sort)
-            .cursor(self.cursor.as_ref())
+            .cursor(
+                self.cursor
+                    .as_ref()
+                    .map(std::convert::AsRef::as_ref)
+                    .unwrap_or_default(),
+            )
             .await;
 
         Some(res)


### PR DESCRIPTION
Querying all scores in a room's playlist can return `"cursor_string": null`, which causes `playlist_scores` to panic since it expected a string. To fix this, I changed `cursor` to be optional.

Please tell me if this issue is not reproducible, or if there's anything I missed.