### PR TITLE
Remove hard requirement for client id/secret

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -83,7 +83,7 @@ impl OsuBuilder {
             http,
             self.timeout,
             Arc::new(ratelimiter),
-            self.retries
+            self.retries,
         ));
 
         #[cfg(feature = "metrics")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -474,7 +474,6 @@ pub(crate) struct OsuInner {
     pub(crate) cache: dashmap::DashMap<crate::prelude::Username, u32>,
 }
 
-#[cfg(feature = "cache")]
 impl OsuInner {
     pub(crate) fn new(
         client_id: Option<u64>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -496,6 +496,7 @@ impl OsuInner {
         }
     }
 
+    #[cfg(feature = "cache")]
     pub(crate) fn update_cache(&self, user_id: u32, username: &crate::prelude::Username) {
         let mut name = username.to_owned();
         name.make_ascii_lowercase();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -482,21 +482,17 @@ impl OsuInner {
         http: HyperClient<HttpsConnector<HttpConnector>, Full<Bytes>>,
         timeout: Duration,
         ratelimiter: Arc<RateLimiter>,
-        retries: u8
+        retries: u8,
     ) -> Self {
-        let boxed_secret = match client_secret {
-            Some(x) => Some(x.into_boxed_str()),
-            None => None,
-        };
-
         Self {
             client_id,
-            client_secret: boxed_secret,
+            client_secret: client_secret.map(String::into_boxed_str),
             http,
             timeout,
             ratelimiter,
             token: CurrentToken::new(),
             retries,
+            #[cfg(feature = "cache")]
             cache: dashmap::DashMap::new(),
         }
     }

--- a/src/client/token.rs
+++ b/src/client/token.rs
@@ -362,10 +362,10 @@ impl AuthorizationKind {
     pub async fn request_token(&self, osu: Arc<OsuInner>) -> OsuResult<TokenResponse> {
         match self {
             AuthorizationKind::User(auth) => match osu.token.get_refresh() {
-                Some(refresh) => TokenFuture::new_refresh(osu, &refresh).await,
-                None => TokenFuture::new_user(osu, auth).await,
+                Some(refresh) => TokenFuture::new_refresh(osu, &refresh)?.await,
+                None => TokenFuture::new_user(osu, auth)?.await,
             },
-            AuthorizationKind::Client => TokenFuture::new_client(osu).await,
+            AuthorizationKind::Client => TokenFuture::new_client(osu)?.await,
             AuthorizationKind::BareToken => {
                 let Some(refresh) = osu.token.get_refresh() else {
                     error!("Missing refresh token on bare authentication; all future requests will fail");
@@ -374,7 +374,7 @@ impl AuthorizationKind {
                     unreachable!();
                 };
 
-                TokenFuture::new_refresh(osu, &refresh).await
+                TokenFuture::new_refresh(osu, &refresh)?.await
             }
         }
     }

--- a/src/future/token.rs
+++ b/src/future/token.rs
@@ -46,11 +46,9 @@ impl TokenRequestGenerator {
             None => return Err(OsuError::BuilderMissingSecret),
         }
 
-        Ok(
-            Self {
-                body: body.into_bytes(),
-            }
-        )
+        Ok(Self {
+            body: body.into_bytes(),
+        })
     }
 
     fn generate(self) -> OsuResult<HyperRequest<Full<Bytes>>> {

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -14,7 +14,7 @@ use rosu_v2::{
         event::EventSort,
         GameMode,
     },
-    prelude::{Token, UserBeatmapsetsKind},
+    prelude::UserBeatmapsetsKind,
     Osu,
 };
 use tokio::sync::{Mutex, MutexGuard};
@@ -57,35 +57,6 @@ impl OsuSingleton {
             let osu = Osu::builder()
                 .client_id(client_id)
                 .client_secret(client_secret)
-                .build()
-                .await
-                .wrap_err("Failed to build osu! client")?;
-
-            if self.inner.set(Mutex::new(osu)).is_err() {
-                eyre::bail!("Failed to set inner cell");
-            }
-        }
-
-        Ok(self.inner.wait().lock().await)
-    }
-
-    async fn get_oauth(&self) -> Result<MutexGuard<'_, Osu>> {
-        let cmp_res = self
-            .initialized
-            .compare_exchange(false, true, SeqCst, SeqCst);
-
-        if cmp_res.is_ok() {
-            tracing_subscriber::fmt()
-                .with_writer(TestWriter::new())
-                .with_env_filter(EnvFilter::builder().parse("rosu_v2=trace,info").unwrap())
-                .init();
-            dotenv().ok();
-
-            let access_token = env::var("OSU_ACCESS_TOKEN")
-                .wrap_err("missing OSU_ACCESS_TOKEN")?;
-
-            let osu = Osu::builder()
-                .with_token(Token::new(&access_token, None), None)
                 .build()
                 .await
                 .wrap_err("Failed to build osu! client")?;
@@ -443,8 +414,9 @@ async fn osu_matches() -> Result<()> {
 }
 
 #[tokio::test]
+#[ignore = "requires OAuth to not throw an error"]
 async fn own_data() -> Result<()> {
-    let user = OSU.get_oauth().await?.own_data().mode(GameMode::Taiko).await?;
+    let user = OSU.get().await?.own_data().mode(GameMode::Taiko).await?;
 
     println!(
         "Received own data showing a last activity of {:?}",
@@ -453,7 +425,6 @@ async fn own_data() -> Result<()> {
 
     Ok(())
 }
-
 
 #[tokio::test]
 async fn performance_rankings() -> Result<()> {


### PR DESCRIPTION
This PR aims to make Authorization Code Grant more ergonomic by removing the hard requirement for client ids and client secrets. With the exception of `/oauth/token` (and maybe some more I missed), no endpoints directly require these fields, so it makes sense to make them largely optional in the builder. It prevents cases like this:
```rs
let osu = OsuBuilder::new()
        .client_id(client_id)
        .client_secret("") // yummy
        .with_token(Token::new(access_token, None), None)
        ...
```
This PR also adds the `own_data` test back in, using an `OSU_ACCESS_TOKEN` environment variable. This in particular has some weird quirks. In my testing, it works when only running that single test:
```
Executing task: cargo test --package rosu-v2 --test requests -- own_data --exact --show-output 

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running tests/requests.rs (target/debug/deps/requests-e8c13b15149d1784)

running 1 test
test own_data ... ok

successes:

---- own_data stdout ----
2025-09-26T21:26:15.030009Z DEBUG rosu_v2::future::request_generator: Performing request... url=https://osu.ppy.sh/api/v2/me/taiko
Received own data showing a last activity of Some(2025-09-26 21:23:39.0 +00:00:00)


successes:
    own_data

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out; finished in 0.51s
```
But fails when running `cargo test`
```
...
test beatmap_user_scores ... ok
test beatmap_difficulty_attributes ... ok
test events ... ok
test beatmap ... ok
test news ... ok
test osu_match ... FAILED // fails on main branch too
test osu_matches ... ok
test own_data ... FAILED
test performance_rankings ... ok
test recent_activity ... ok
test score ... ok
test score_rankings ... ok
...
```
I assume it's a quirk with the `OsuSingleton`, but it might be worth looking into before merging.
