### PR TITLE
Add basic changelog API support

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -205,6 +205,16 @@ impl Osu {
         GetComments::new(self)
     }
 
+    #[inline]
+    pub const fn changelog_build(&self, stream: String, build: String) -> GetChangelogBuild<'_> {
+        GetChangelogBuild::new(self, stream, build)
+    }
+
+    #[inline]
+    pub fn changelog_listing(&self) -> GetChangelogListing<'_> {
+        GetChangelogListing::new(self)
+    }
+
     /// Get a [`ChartRankings`](crate::model::ranking::ChartRankings) struct
     /// containing a [`Spotlight`](crate::model::ranking::Spotlight), its
     /// [`BeatmapsetExtended`](crate::model::beatmap::BeatmapsetExtended)s, and participating

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ pub mod prelude {
         error::OsuError,
         model::{
             beatmap::*,
+            changelog::*,
             comments::*,
             event::*,
             forum::*,

--- a/src/model/changelog.rs
+++ b/src/model/changelog.rs
@@ -1,0 +1,124 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use super::serde_util;
+use crate::model::ContainedUsers;
+
+/// Changelog listing entry
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChangelogListing {
+    /// List of all game update streams (stable, lazer, etc)
+    pub streams: Vec<Stream>,
+    /// List of builds included
+    pub builds: Vec<Build>,
+    /// Search query inputs
+    pub search: Search,
+}
+
+impl ContainedUsers for ChangelogListing {
+    fn apply_to_users(&self, _f: impl super::CacheUserFn) {}
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Stream {
+    /// Build stream ID
+    pub id: i64,
+    /// Build stream title (stable40, lazer, etc)
+    pub name: String,
+    /// User-friendly build stream name
+    pub display_name: String,
+    /// Whether the build is displayed
+    pub is_featured: bool,
+    /// Latest deployed build information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_build: Option<Box<Build>>,
+    /// Current live user count
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_count: Option<i64>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Build {
+    /// Release build ID
+    pub id: i64,
+    /// Release build version
+    pub version: Option<String>,
+    /// User-friendly release build version
+    pub display_version: String,
+    /// Current live user count for the build
+    pub users: i64,
+    /// Build release date
+    #[serde(with = "serde_util::datetime")]
+    pub created_at: OffsetDateTime,
+    pub update_stream: Option<Stream>, // it is tagged as nullable but why would it be?
+    pub changelog_entries: Option<Vec<ChangelogEntry>>,
+    pub youtube_id: Option<String>,
+    /// Previous and next versions to this build
+    pub versions: Option<Versions>,
+}
+
+impl ContainedUsers for Build {
+    fn apply_to_users(&self, _f: impl super::CacheUserFn) {}
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Versions {
+    pub next: Option<Box<Build>>,
+    pub previous: Option<Box<Build>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChangelogEntry {
+    pub id: Option<i64>,
+    pub repository: Option<String>,
+    pub github_pull_request_id: Option<i64>,
+    pub github_url: Option<String>,
+    /// Changelog entry URL in the news listing
+    pub url: Option<String>,
+    #[serde(rename = "type")]
+    /// Changelog entry type
+    pub entry_type: String, // TODO, technically defined but I can't read PHP
+    /// Changelog category
+    pub category: Option<String>, // TODO, technically defined but I can't read PHP
+    /// Changelog entry title
+    pub title: Option<String>,
+    #[cfg_attr(
+        feature = "serialize",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_html: Option<String>,
+    pub major: bool,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "serde_util::option_datetime"
+    )]
+    pub created_at: Option<OffsetDateTime>,
+    pub github_user: GithubUser,
+}
+
+/// Github user behind the specific change
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GithubUser {
+    /// Display name of the user, may differ from github
+    pub display_name: String,
+    /// Github profile URL
+    pub github_url: Option<String>,
+    /// Github username
+    pub github_username: Option<String>,
+    pub id: Option<i64>,
+    pub osu_username: Option<String>,
+    pub user_id: Option<i64>,
+    pub user_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Search {
+    pub stream: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub max_id: Option<i64>,
+    pub limit: i64,
+}

--- a/src/model/changelog.rs
+++ b/src/model/changelog.rs
@@ -6,6 +6,7 @@ use crate::model::ContainedUsers;
 
 /// Changelog listing entry
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ChangelogListing {
     /// List of all game update streams (stable, lazer, etc)
     pub streams: Vec<Stream>,
@@ -20,6 +21,7 @@ impl ContainedUsers for ChangelogListing {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Stream {
     /// Build stream ID
     pub id: i64,
@@ -38,6 +40,7 @@ pub struct Stream {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Build {
     /// Release build ID
     pub id: i64,
@@ -62,12 +65,14 @@ impl ContainedUsers for Build {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Versions {
     pub next: Option<Box<Build>>,
     pub previous: Option<Box<Build>>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct ChangelogEntry {
     pub id: Option<i64>,
     pub repository: Option<String>,
@@ -101,6 +106,7 @@ pub struct ChangelogEntry {
 
 /// Github user behind the specific change
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct GithubUser {
     /// Display name of the user, may differ from github
     pub display_name: String,
@@ -115,6 +121,7 @@ pub struct GithubUser {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 pub struct Search {
     pub stream: Option<String>,
     pub from: Option<String>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -171,7 +171,9 @@ pub mod seasonal_backgrounds;
 /// User related types
 pub mod user;
 
+/// Changelog related types
 pub mod changelog;
+
 /// Wiki related types
 pub mod wiki;
 

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -171,6 +171,7 @@ pub mod seasonal_backgrounds;
 /// User related types
 pub mod user;
 
+pub mod changelog;
 /// Wiki related types
 pub mod wiki;
 

--- a/src/request/changelog.rs
+++ b/src/request/changelog.rs
@@ -1,0 +1,98 @@
+use crate::{
+    prelude::{Build, ChangelogListing},
+    request::{Query, Request},
+    routing::Route,
+    Osu,
+};
+
+use serde::Serialize;
+
+#[must_use = "requests must be configured and executed"]
+#[derive(Serialize)]
+pub struct GetChangelogBuild<'a> {
+    #[serde(skip)]
+    osu: &'a Osu,
+    stream: String,
+    build: String,
+}
+
+impl<'a> GetChangelogBuild<'a> {
+    pub(crate) const fn new(osu: &'a Osu, stream: String, build: String) -> Self {
+        Self { osu, stream, build }
+    }
+}
+
+into_future! {
+    |self: GetChangelogBuild<'_>| -> Build {
+        let route = Route::GetChangelogBuild {
+            stream: self.stream,
+            build: self.build,
+        };
+
+        Request::new(route)
+    }
+}
+
+#[must_use = "requests must be configured and executed"]
+#[derive(Serialize)]
+pub struct GetChangelogListing<'a> {
+    #[serde(skip)]
+    osu: &'a Osu,
+    from: Option<&'a str>,
+    to: Option<&'a str>,
+    max_id: Option<&'a str>,
+    stream: Option<&'a str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    message_formats: Vec<&'a str>,
+}
+
+impl<'a> GetChangelogListing<'a> {
+    pub(crate) fn new(osu: &'a Osu) -> Self {
+        Self {
+            osu,
+            from: None,
+            to: None,
+            max_id: None,
+            // There are only two supported formats, it should be fine
+            message_formats: Vec::with_capacity(2).into(),
+            stream: None,
+        }
+    }
+
+    /// Specify minimum build version
+    #[inline]
+    pub fn from(mut self, from: &'a str) -> Self {
+        self.from = Some(from);
+
+        self
+    }
+
+    /// Specify maximum build version
+    pub fn to(mut self, to: &'a str) -> Self {
+        self.to = Some(to);
+
+        self
+    }
+
+    /// Specify the release stream
+    pub fn stream(mut self, stream: &'a str) -> Self {
+        self.stream = Some(stream);
+
+        self
+    }
+
+    pub fn message_formats<I>(mut self, message_formats: I) -> Self
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        self.message_formats = message_formats.into_iter().collect();
+
+        self
+    }
+}
+
+into_future! {
+    |self: GetChangelogListing<'_>| -> ChangelogListing {
+        Request::with_query(Route::GetChangelogListing, Query::encode(&self))
+    }
+}

--- a/src/request/changelog.rs
+++ b/src/request/changelog.rs
@@ -61,21 +61,21 @@ impl<'a> GetChangelogListing<'a> {
 
     /// Specify minimum build version
     #[inline]
-    pub fn from(mut self, from: &'a str) -> Self {
+    pub const fn from(mut self, from: &'a str) -> Self {
         self.from = Some(from);
 
         self
     }
 
     /// Specify maximum build version
-    pub fn to(mut self, to: &'a str) -> Self {
+    pub const fn to(mut self, to: &'a str) -> Self {
         self.to = Some(to);
 
         self
     }
 
     /// Specify the release stream
-    pub fn stream(mut self, stream: &'a str) -> Self {
+    pub const fn stream(mut self, stream: &'a str) -> Self {
         self.stream = Some(stream);
 
         self

--- a/src/request/changelog.rs
+++ b/src/request/changelog.rs
@@ -54,7 +54,7 @@ impl<'a> GetChangelogListing<'a> {
             to: None,
             max_id: None,
             // There are only two supported formats, it should be fine
-            message_formats: Vec::with_capacity(2).into(),
+            message_formats: Vec::new(),
             stream: None,
         }
     }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -139,11 +139,12 @@ use crate::routing::Route;
 pub use crate::future::OsuFuture;
 
 pub use self::{
-    beatmap::*, comments::*, event::*, forum::*, matches::*, news::*, ranking::*, replay::*,
-    score::*, seasonal_backgrounds::*, user::*, wiki::*,
+    beatmap::*, changelog::*, comments::*, event::*, forum::*, matches::*, news::*, ranking::*,
+    replay::*, score::*, seasonal_backgrounds::*, user::*, wiki::*,
 };
 
 mod beatmap;
+mod changelog;
 mod comments;
 mod event;
 mod forum;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -30,6 +30,11 @@ pub(crate) enum Route {
     GetBeatmapsetFromMapId,
     GetBeatmapsetEvents,
     GetBeatmapsetSearch,
+    GetChangelogBuild {
+        stream: String,
+        build: String,
+    },
+    GetChangelogListing,
     GetComments,
     GetEvents,
     GetForumPosts {
@@ -112,6 +117,10 @@ impl Route {
             Self::GetBeatmapsetFromMapId => (Method::Get, "beatmapsets/lookup".into()),
             Self::GetBeatmapsetEvents => (Method::Get, "beatmapsets/events".into()),
             Self::GetBeatmapsetSearch => (Method::Get, "beatmapsets/search".into()),
+            Self::GetChangelogBuild { stream, build } => {
+                (Method::Get, format!("changelog/{stream}/{build}").into())
+            }
+            Self::GetChangelogListing => (Method::Get, "changelog".into()),
             Self::GetComments => (Method::Get, "comments".into()),
             Self::GetEvents => (Method::Get, "events".into()),
             Self::GetForumPosts { topic_id } => {
@@ -216,6 +225,8 @@ impl Route {
             Self::GetBeatmapsetFromMapId => "GetBeatmapsetFromMapId",
             Self::GetBeatmapsetEvents => "GetBeatmapsetEvents",
             Self::GetBeatmapsetSearch => "GetBeatmapsetSearch",
+            Self::GetChangelogBuild { .. } => "GetChangelogBuild",
+            Self::GetChangelogListing => "GetChangelogListing",
             Self::GetComments => "GetComments",
             Self::GetEvents => "GetEvents",
             Self::GetForumPosts { .. } => "GetForumPosts",

--- a/tests/requests.rs
+++ b/tests/requests.rs
@@ -657,3 +657,12 @@ async fn wiki() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn changelogs() -> Result<()> {
+    let changelog = OSU.get().await?.changelog_listing().await?;
+
+    println!("Received {} changelog listings", changelog.builds.len());
+
+    Ok(())
+}


### PR DESCRIPTION
Adds support for /changelog and /changelog/{stream}/{build} with baseline coverage. Not entirely sure on cleanliness, but this should be good enough as a base

Handy for user count data by the way