### PR TITLE
feat: Add multiplayer.write_manage scope

### DIFF
--- a/src/client/scopes.rs
+++ b/src/client/scopes.rs
@@ -76,6 +76,8 @@ define_scopes! {
     Identify: 6, "identify";
     /// Allows reading of publicly available data on behalf of the user.
     Public: 7, "public";
+    /// Allows creating and managing multiplayer rooms on a user's behalf.
+    MultiplayerWriteManage: 8, "multiplayer.write_manage";
 }
 
 impl Default for Scopes {


### PR DESCRIPTION
With the addition of the [SignalR Referee API](https://ppy.sh/osu-server-spectator/referee-hub-api.html), a new OAuth scope has been added: [multiplayer.write_manage](https://osu.ppy.sh/docs/index.html#scopes).