### PR TITLE
fix(serde_util): use calendar year component for date deserialization

### DIFF
--- a/src/model/serde_util.rs
+++ b/src/model/serde_util.rs
@@ -8,15 +8,17 @@ use serde::{
     Deserialize, Deserializer,
 };
 use time::format_description::{
-    modifier::{Day, Month, Year},
+    modifier::{CalendarYearFullStandardRange, Day, MonthNumerical},
     Component, FormatItem,
 };
 
 const DATE_FORMAT: &[FormatItem<'_>] = &[
-    FormatItem::Component(Component::Year(Year::default())),
-    FormatItem::Literal(b"-"),
-    FormatItem::Component(Component::Month(Month::default())),
-    FormatItem::Literal(b"-"),
+    FormatItem::Component(Component::CalendarYearFullStandardRange(
+        CalendarYearFullStandardRange::default(),
+    )),
+    FormatItem::StringLiteral("-"),
+    FormatItem::Component(Component::MonthNumerical(MonthNumerical::default())),
+    FormatItem::StringLiteral("-"),
     FormatItem::Component(Component::Day(Day::default())),
 ];
 


### PR DESCRIPTION
`osu.user(user_id)` currently fails with `OsuError::Parsing` for every user whose profile contains `monthly_playcounts` (i.e. virtually all of them), because the deserializer hits the first `start_date: "YYYY-MM-DD"` string.