### PR TITLE
fix(serde_util): use calendar year component for date deserialization

### DIFF
--- a/src/model/serde_util.rs
+++ b/src/model/serde_util.rs
@@ -8,13 +8,13 @@ use serde::{
     Deserialize, Deserializer,
 };
 use time::format_description::{
-    modifier::{Day, IsoYearFullStandardRange, MonthNumerical},
+    modifier::{CalendarYearFullStandardRange, Day, MonthNumerical},
     Component, FormatItem,
 };
 
 const DATE_FORMAT: &[FormatItem<'_>] = &[
-    FormatItem::Component(Component::IsoYearFullStandardRange(
-        IsoYearFullStandardRange::default(),
+    FormatItem::Component(Component::CalendarYearFullStandardRange(
+        CalendarYearFullStandardRange::default(),
     )),
     FormatItem::StringLiteral("-"),
     FormatItem::Component(Component::MonthNumerical(MonthNumerical::default())),

--- a/tests/deserialize_date.rs
+++ b/tests/deserialize_date.rs
@@ -1,0 +1,20 @@
+use rosu_v2::prelude::MonthlyCount;
+use time::Date;
+
+#[test]
+fn deserialize_monthly_playcounts() {
+    // Real data from osu! API: user.monthly_playcounts[]
+    let json = r#"[
+        { "start_date": "2007-10-01", "count": 483 },
+        { "start_date": "2007-11-01", "count": 381 },
+        { "start_date": "2007-12-01", "count": 94 }
+    ]"#;
+
+    let counts: Vec<MonthlyCount> = serde_json::from_str(json).unwrap();
+
+    assert_eq!(counts.len(), 3);
+    assert_eq!(counts[0].start_date, Date::from_calendar_date(2007, time::Month::October, 1).unwrap());
+    assert_eq!(counts[0].count, 483);
+    assert_eq!(counts[2].start_date, Date::from_calendar_date(2007, time::Month::December, 1).unwrap());
+    assert_eq!(counts[2].count, 94);
+}


### PR DESCRIPTION
`osu.user(user_id)` currently fails with `OsuError::Parsing` for every user whose profile contains `monthly_playcounts` (i.e. virtually all of them), because the deserializer hits the first `start_date: "YYYY-MM-DD"` string.