### PR TITLE
refactor!: replace smallstr with compact_str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ deny_unknown_fields = []
 
 [dependencies]
 bytes = { version = "1.10.0", default-features = false }
+compact_str = { version = "0.10.0", default-features = false, features = ["serde"] }
 futures = { version = "0.3", default-features = false }
 leaky-bucket = { version = "1.1.2" }
 http-body-util = { version = "0.1.2", default-features = false }
@@ -37,7 +38,6 @@ rosu-mods = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "raw_value"] }
 serde_urlencoded = { version = "0.7.1" }
-smallstr = { version = "0.3.0", features = ["serde"] }
 thiserror = { version = "2.0.11" }
 time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.0", default-features = false, features = ["macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,8 @@ pub mod prelude {
         Osu, OsuBuilder, OsuResult,
     };
 
+    pub use compact_str::CompactString;
     pub use hyper::StatusCode;
-    pub use smallstr::SmallString;
 
     #[cfg(feature = "macros")]
     #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]

--- a/src/model/serde_util.rs
+++ b/src/model/serde_util.rs
@@ -23,7 +23,6 @@ const DATE_FORMAT: &[FormatItem<'_>] = &[
 ];
 
 pub(super) mod datetime {
-
     use serde::Deserializer;
     use time::{serde::rfc3339, OffsetDateTime};
 
@@ -41,7 +40,6 @@ pub(super) mod datetime {
 }
 
 pub(super) mod option_datetime {
-
     use serde::Deserializer;
     use time::{serde::rfc3339, OffsetDateTime};
 
@@ -79,7 +77,6 @@ pub(super) mod adjust_acc {
 }
 
 pub(super) mod from_option {
-
     use serde::{Deserialize, Deserializer};
 
     pub fn deserialize<'de, D: Deserializer<'de>, T>(d: D) -> Result<T, D::Error>

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,14 +1,15 @@
-use crate::model::chat::ChatSilenceId;
+use std::fmt;
 
-use super::{serde_util, CacheUserFn, ContainedUsers, GameMode};
-
+use compact_str::CompactString;
 use serde::{
     de::{Error, IgnoredAny, MapAccess, SeqAccess, Visitor},
     Deserialize, Deserializer,
 };
-use smallstr::SmallString;
-use std::fmt;
 use time::{Date, OffsetDateTime};
+
+use crate::model::chat::ChatSilenceId;
+
+use super::{serde_util, CacheUserFn, ContainedUsers, GameMode};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
@@ -36,7 +37,7 @@ pub struct Badge {
 }
 
 /// Country codes are at most 2 ASCII characters long
-pub type CountryCode = SmallString<[u8; 2]>;
+pub type CountryCode = CompactString;
 
 struct CountryVisitor;
 
@@ -815,8 +816,8 @@ impl UserLevel {
     }
 }
 
-/// osu! usernames are at most 15 ASCII characters long
-pub type Username = SmallString<[u8; 15]>;
+/// osu! usernames are generally no longer than 15 ASCII characters.
+pub type Username = CompactString;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]

--- a/src/request/user.rs
+++ b/src/request/user.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use itoa::Buffer;
 use serde::Serialize;
-use smallstr::SmallString;
 
 use crate::{
     model::{
@@ -51,21 +50,21 @@ impl From<u32> for UserId {
 impl From<&str> for UserId {
     #[inline]
     fn from(name: &str) -> Self {
-        Self::Name(SmallString::from_str(name))
+        Self::Name(Username::new(name))
     }
 }
 
 impl From<&String> for UserId {
     #[inline]
     fn from(name: &String) -> Self {
-        Self::Name(SmallString::from_str(name))
+        Self::Name(Username::new(name))
     }
 }
 
 impl From<String> for UserId {
     #[inline]
     fn from(name: String) -> Self {
-        Self::Name(SmallString::from_string(name))
+        Self::Name(Username::new(name))
     }
 }
 


### PR DESCRIPTION
Closes #74 

`smallstr` was generally bigger than `String` so even if it didn't allocate, `compact_str` will bring an overall performance improvement. It does bring in another opinionated dependency but arguably `compact_str` is sufficiently popular by now so it's justified.