### PR TITLE
feat: ranked play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ Cargo.lock
 output.*
 expanded.*
 /tests/custom.rs
+/scripts
 /.vscode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@ pub mod prelude {
             forum::*,
             kudosu::*,
             matches::*,
+            matchmaking::*,
             mods::{generated_mods::*, Acronym, GameMods, GameModsIntermode, GameModsLegacy},
             multiplayer::*,
             news::*,

--- a/src/model/beatmap.rs
+++ b/src/model/beatmap.rs
@@ -469,6 +469,7 @@ fn deser_mapset_user<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Box<User>
                 is_nat: None,
                 is_silenced: None,
                 loved_mapset_count: None,
+                matchmaking_stats: None,
                 medals: None,
                 monthly_playcounts: None,
                 page: None,

--- a/src/model/matchmaking.rs
+++ b/src/model/matchmaking.rs
@@ -1,0 +1,99 @@
+use rosu_mods::GameMode;
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+/// The type of a [`MatchmakingPool`].
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MatchmakingPoolType {
+    /// Quick play.
+    QuickPlay,
+    /// Ranked play.
+    RankedPlay,
+}
+
+/// The result of a match in a [`MatchmakingPool`].
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[serde(rename_all = "snake_case")]
+pub enum MatchmakingResult {
+    Win,
+    Loss,
+    Draw,
+}
+
+/// A matchmaking pool users can play in.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct MatchmakingPool {
+    /// Whether the pool is currently active.
+    pub active: bool,
+    /// Unique identifier of the pool.
+    #[serde(rename = "id")]
+    pub pool_id: u32,
+    /// Display name of the pool.
+    pub name: String,
+    /// The game mode of the pool.
+    #[serde(rename = "ruleset_id")]
+    pub mode: GameMode,
+    /// The type of the pool.
+    #[serde(rename = "type")]
+    pub kind: MatchmakingPoolType,
+    /// The variant of the pool (`0` for no variant).
+    pub variant_id: u32,
+}
+
+/// A single elo history entry of a user in a [`MatchmakingPool`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct MatchmakingUserEloHistory {
+    /// The elo of the user after the match.
+    pub elo_after: i32,
+    /// Unique identifier of the entry.
+    #[serde(rename = "id")]
+    pub entry_id: u32,
+    /// When the entry was created.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "super::serde_util::option_datetime"
+    )]
+    pub created_at: Option<OffsetDateTime>,
+    /// The result of the match.
+    pub result: MatchmakingResult,
+}
+
+/// The ranked play (matchmaking) stats of a user in a single pool.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+pub struct MatchmakingUserStats {
+    /// The number of first placements.
+    pub first_placements: u32,
+    /// Whether the rating of the user is still provisional.
+    pub is_rating_provisional: bool,
+    /// The number of plays.
+    pub plays: u32,
+    /// Unique identifier of the pool the stats belong to.
+    pub pool_id: u32,
+    /// The rank of the user in the pool (`1` being the highest).
+    pub rank: u32,
+    /// The percentile rank of the user in the pool (`0.0` to `1.0`).
+    pub rank_percent: f64,
+    /// The current rating of the user in the pool.
+    pub rating: i32,
+    /// The total points of the user in the pool.
+    pub total_points: i32,
+    /// Unique identifier of the user.
+    pub user_id: u32,
+
+    /// The pool the stats belong to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pool: Option<MatchmakingPool>,
+    /// Recent elo history entries of the user in the pool.
+    ///
+    /// `None` if the pool is not active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recent_history: Option<Vec<MatchmakingUserEloHistory>>,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -156,6 +156,9 @@ pub mod kudosu;
 /// Multiplayer match related types
 pub mod matches;
 
+/// Matchmaking related types
+pub mod matchmaking;
+
 /// Re-exports of `rosu-mods`
 pub mod mods;
 

--- a/src/model/multiplayer.rs
+++ b/src/model/multiplayer.rs
@@ -392,4 +392,5 @@ pub enum RoomTypeGroup {
     TeamVersus,
     TagCoop,
     TagTeamVersus,
+    RankedPlay,
 }

--- a/src/model/ranking.rs
+++ b/src/model/ranking.rs
@@ -495,6 +495,7 @@ impl<'u> UserWithoutStats<'u> {
             scores_recent_count,
             statistics: _,
             statistics_modes: _,
+            matchmaking_stats: _,
             support_level,
             pending_mapset_count,
             team,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -8,6 +8,7 @@ use serde::{
 use time::{Date, OffsetDateTime};
 
 use crate::model::chat::ChatSilenceId;
+use crate::model::matchmaking::MatchmakingUserStats;
 
 use super::{serde_util, CacheUserFn, ContainedUsers, GameMode};
 
@@ -453,6 +454,8 @@ pub struct UserExtended {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mapping_follower_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matchmaking_stats: Option<Vec<MatchmakingUserStats>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub monthly_playcounts: Option<Vec<MonthlyCount>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub page: Option<UserPage>,
@@ -618,6 +621,8 @@ pub struct User {
         skip_serializing_if = "Option::is_none"
     )]
     pub loved_mapset_count: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matchmaking_stats: Option<Vec<MatchmakingUserStats>>,
     #[serde(
         default,
         rename = "user_achievements",
@@ -713,6 +718,7 @@ impl From<UserExtended> for User {
             is_nat: user.is_nat,
             is_silenced: user.is_silenced,
             loved_mapset_count: user.loved_mapset_count,
+            matchmaking_stats: user.matchmaking_stats,
             medals: user.medals,
             monthly_playcounts: user.monthly_playcounts,
             page: user.page,

--- a/src/request/multiplayer.rs
+++ b/src/request/multiplayer.rs
@@ -209,11 +209,12 @@ pub enum RoomsSort {
 
 /// The "type group" for [`GetRooms`].
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum RoomsTypeGroup {
     #[default]
     Playlists,
+    RankedPlay,
     Realtime,
 }
 

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -18,6 +18,7 @@ mod types {
                     catch: None,
                     mania: None,
                 },
+                matchmaking_stats: None,
                 ..get_user()
             }],
             spotlight: get_spotlight(),
@@ -104,7 +105,10 @@ mod types {
             can_be_hyped: true,
             converts: Some(vec![]),
             covers: get_mapset_covers(),
-            creator: Some(Box::new(get_user())),
+            creator: Some(Box::new(User {
+                matchmaking_stats: None,
+                ..get_user()
+            })),
             creator_name: "god".into(),
             creator_id: 2,
             description: Some("description".to_owned()),
@@ -791,6 +795,52 @@ mod types {
         }
     }
 
+    pub(super) fn get_matchmaking_pool() -> MatchmakingPool {
+        MatchmakingPool {
+            active: true,
+            pool_id: 1,
+            name: "ranked play".to_owned(),
+            mode: GameMode::Osu,
+            kind: MatchmakingPoolType::RankedPlay,
+            variant_id: 0,
+        }
+    }
+
+    pub(super) fn get_matchmaking_user_stats() -> MatchmakingUserStats {
+        MatchmakingUserStats {
+            first_placements: 12,
+            is_rating_provisional: true,
+            plays: 123,
+            pool_id: 1,
+            rank: 42,
+            rank_percent: 0.95,
+            rating: 1500,
+            total_points: 4567,
+            user_id: 12345,
+            pool: Some(get_matchmaking_pool()),
+            recent_history: Some(vec![
+                MatchmakingUserEloHistory {
+                    elo_after: 1500,
+                    entry_id: 1,
+                    created_at: Some(get_date()),
+                    result: MatchmakingResult::Win,
+                },
+                MatchmakingUserEloHistory {
+                    elo_after: 1450,
+                    entry_id: 2,
+                    created_at: Some(get_date()),
+                    result: MatchmakingResult::Loss,
+                },
+                MatchmakingUserEloHistory {
+                    elo_after: 1450,
+                    entry_id: 3,
+                    created_at: Some(get_date()),
+                    result: MatchmakingResult::Draw,
+                },
+            ]),
+        }
+    }
+
     pub(super) fn get_user_extended() -> UserExtended {
         UserExtended {
             avatar_url: String::new(),
@@ -886,6 +936,7 @@ mod types {
             is_nat: Some(true),
             is_silenced: Some(true),
             loved_mapset_count: Some(3),
+            matchmaking_stats: Some(vec![get_matchmaking_user_stats()]),
             mapping_follower_count: Some(5),
             monthly_playcounts: Some(vec![MonthlyCount {
                 start_date: Date::from_ordinal_date(2017, 1).unwrap(),
@@ -982,6 +1033,7 @@ mod types {
             is_nat: Some(false),
             is_silenced: Some(false),
             loved_mapset_count: Some(34),
+            matchmaking_stats: Some(vec![get_matchmaking_user_stats()]),
             medals: Some(vec![MedalCompact {
                 achieved_at: get_date(),
                 medal_id: 1,


### PR DESCRIPTION
User data now includes matchmaking info and room retrieval can be done for ranked play. Beware that the API seems to return 500s occasionally for the latter, likely an internal bug. Usually works when filtering for "ended" or filtering for "all" but sorting by "ended".